### PR TITLE
Update netlify-cms config to this repository

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -1,11 +1,11 @@
 backend:
   name: github
-  repo: 18f/federalist-uswds-jekyll
+  repo: atbcb/usab-uswds
   base_url: https://federalistapp.18f.gov
   auth_endpoint: external/auth/github
   preview_context: federalist/build
   branch: master
-  use_graphql: true
+  use_graphql: false
 
 media_folder: assets/uploads
 public_folder: /images/uploads


### PR DESCRIPTION
When an authorized contributor of this repository goes to the https://federalist-e3fba26d-2806-4f02-bf0e-89c97cfba93c.app.cloud.gov/site/atbcb/usab-uswds/admin, the Netlify CMS GUI will authenticate them and take them to the UI to add and edit content.

## How to test
Go to https://federalist-e3fba26d-2806-4f02-bf0e-89c97cfba93c.app.cloud.gov/preview/atbcb/usab-uswds/apb-fix-netlify-cms/admin/ and attempt to log into the Netlify CMS GUI

## Acceptance Criteria
- [x] Update `admin/config.yml` to point to this _atbcb/usab-uswds_ repository
- [ ] Authorized user can login

## Bug fixes
- [ ] Allows contributors to this repo access to the Netlify CMS GUI