### PR TITLE
Update dot-prop dependency to fix dependabot security alert

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1502,9 +1502,9 @@
       "integrity": "sha1-kfJS5Ze2Wvd+dFriTdAYXV4m1Yw="
     },
     "dot-prop": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
-      "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.1.tgz",
+      "integrity": "sha512-l0p4+mIuJIua0mhxGoh4a+iNL9bmeK5DvnSVQa6T0OhrVmaEa1XScX5Etc673FePCJOArq/4Pa2cLGODUWTPOQ==",
       "dev": true,
       "requires": {
         "is-obj": "^1.0.0"


### PR DESCRIPTION
Bumped up `dot-prop` NPM dependency to fix security alert from dependabot.

## Acceptance criterial
- [x] Fixes the security alert from dependabot to upgrade `dot-prop`
- [x] Ran `npm audit fix` to upgrade the dependency
