### PR TITLE
Update enhanced-ada.html

### DIFF
--- a/_pages/guidelines-standards/enhanced-ada.html
+++ b/_pages/guidelines-standards/enhanced-ada.html
@@ -5894,3 +5894,10 @@ right-sidenav: ada-right-sidenav.html
 
 
 <!-- END FROM STANDARDS ONLY FILE -->	
+<script>
+    var v = document.getElementsByClassName("data"); 
+    var i;
+    for (i = 0; i < v.length; i++) {
+      v[i].className += " usa-table";
+    }
+  </script>


### PR DESCRIPTION
script adds "usa-table" to all tables with class="data". 

If this works for you @RSD-accessboard, I can add the script to the ABA standards files but those aren't in a single file. Do you know add a script link to that folder of files?