### PR TITLE
Add fixes to the Federalist checkmarx scan

### DIFF
--- a/_assets/js/toc-subnav.js
+++ b/_assets/js/toc-subnav.js
@@ -26,11 +26,12 @@
     if (elements) {
       for (let i = 0; i < elements.length; i++) {
         let section = elements[i].innerText;
+        let cleanedSection = DOMPurify.sanitize(section);
 
-        // if section is empty go to next element in loop
-        if (section === "") continue;
+        // if cleanedSection is empty go to next element in loop
+        if (cleanedSection === "") continue;
 
-        let idtag = section.replace(/ /g,"-");
+        let idtag = cleanedSection.replace(/ /g,"-");
         let currentAnchorClass = currentAnchor === idtag ?
           'class="usa-current"' : 'class=""';
         elements[i].setAttribute("id",idtag);
@@ -38,7 +39,8 @@
         let li = "<li><a " + currentAnchorClass + " href=\"#" + idtag + "\">" + section + "</a></li>";
 
         if (subsections) {
-          subsections.innerHTML += li;
+          let cleanedItem = DOMPurify.sanitize(li);
+          subsections.innerHTML += cleanedItem;
         }
       };
     }

--- a/_config.yml
+++ b/_config.yml
@@ -378,6 +378,8 @@ exclude:
 
 assets:
   sources:
+    - node_modules/dompurify/dist/
+    - node_modules/stickyfilljs/dist
     - node_modules/uswds/dist/img
     - node_modules/uswds/dist/js
     - node_modules/uswds/dist/scss

--- a/_ict/ch7.html
+++ b/_ict/ch7.html
@@ -30,7 +30,7 @@ order-number: 11
             Archives Code of Federal Regulations Incorporation by Reference</a>.</p>
     <h4 id="702.2">702.2 Advanced Television Systems Committee (ATSC)</h4>
     <p class="dot1desc"> Copies of the referenced standard may be obtained from the <a href="http://www.atsc.org"
-            target="_blank">Advanced Television Systems Committee</a>, 1776 K Street NW, Suite 200, Washington, DC
+            target="_blank" rel="noreferrer">Advanced Television Systems Committee</a>, 1776 K Street NW, Suite 200, Washington, DC
         20006–2304.
     </p>
     <div class="dotdot">
@@ -58,7 +58,7 @@ order-number: 11
     </div>
     <h4 id="702.5">702.5 Institute of Electrical and Electronics Engineers (IEEE)</h4>
     <p class="dot1desc"> Copies of the referenced standard may be obtained from the <a href="http://www.ieee.org"
-            target="_blank">Institute of Electrical and Electronics Engineers</a>, 10662 Los Vaqueros Circle, P.O. Box
+            target="_blank" rel="noreferrer">Institute of Electrical and Electronics Engineers</a>, 10662 Los Vaqueros Circle, P.O. Box
         3014,
         Los Alamitos, CA 90720–1264.</p>
     <div class="dotdot">
@@ -68,7 +68,7 @@ order-number: 11
     </div>
     <h4 id="702.6">702.6 International Code Council (ICC)</h4>
     <p class="dot1desc"> Copies of the referenced standard may be obtained from <a href="http://www.iccsafe.org"
-            target="_blank">ICC Publications</a>, 4051 W. Flossmoor Road, Country Club Hills, IL 60478–5795.</p>
+            target="_blank" rel="noreferrer">ICC Publications</a>, 4051 W. Flossmoor Road, Country Club Hills, IL 60478–5795.</p>
     <div class="dotdot">
         <h5 id="702.6.1">702.6.1 ICC A117.1-2009, Accessible and Usable Buildings and Facilities, approved October 20,
             2010
@@ -77,7 +77,7 @@ order-number: 11
     </div>
     <h4 id="702.7">702.7 International Telecommunications Union Telecommunications Standardization Sector (ITU-T)</h4>
     <p class="dot1desc"> Copies of the referenced standards may be obtained from the <a
-            href="http://www.itu.int/en/ITU-T" target="_blank">International Telecommunication Union</a>,
+            href="http://www.itu.int/en/ITU-T" target="_blank" rel="noreferrer">International Telecommunication Union</a>,
         Telecommunications Standardization Sector, Place des
         Nations CH-1211, Geneva 20, Switzerland.</p>
     <div class="dotdot">
@@ -97,7 +97,7 @@ order-number: 11
     </div>
     <h4 id="702.8">702.8 Internet Engineering Task Force (IETF)</h4>
     <p class="dot1desc"> Copies of the referenced standard may be obtained from the <a href="http://www.ietf.org"
-            target="_blank">Internet Engineering Task Force</a>.</p>
+            target="_blank" rel="noreferrer">Internet Engineering Task Force</a>.</p>
     <div class="dotdot">
         <h5 id="702.8.1">702.8.1 IETF RFC 6716, Definition of the Opus Codec, September 2012, J.M. Valin, Mozilla
             Corporation, K. Vos, Skype Technologies S.A., T. Terriberry, Mozilla Corporation</h5>
@@ -106,7 +106,7 @@ order-number: 11
     <h4 id="702.9">702.9 Telecommunications Industry Association (TIA)</h4>
     <p class="dot1desc"> Copies of the referenced standard, published by the Telecommunications Industry Association,
         may
-        be obtained from <a href="http://global.ihs.com" target="_blank">IHS Markit</a>, 15 Inverness Way East,
+        be obtained from <a href="http://global.ihs.com" target="_blank" rel="noreferrer">IHS Markit</a>, 15 Inverness Way East,
         Englewood,
         CO 80112.</p>
     <div class="dotdot">
@@ -118,7 +118,7 @@ order-number: 11
     <p class="dot1desc"> Copies of the referenced standard may be obtained from the W3C Web Accessibility Initiative,
         Massachusetts Institute of Technology, 32 Vassar Street, Room 32-G515, Cambridge, MA 02139.</p>
     <div class="dotdot">
-        <h5 id="702.10.1">702.10.1 <a href="http://www.w3.org/TR/WCAG20" target="_blank">WCAG 2.0, Web Content
+        <h5 id="702.10.1">702.10.1 <a href="http://www.w3.org/TR/WCAG20" target="_blank" rel="noreferrer">WCAG 2.0, Web Content
                 Accessibility
                 Guidelines</a>, W3C Recommendation, December 11, 2008</h5>
         <p class="dotdotdesc">IBR approved for: Appendix A (Section 508 of the Rehabilitation Act: Application and

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -6,6 +6,7 @@
 
 {% asset uswds.min.js %}
 {% asset stickyfill.js %}
+{% asset purify.min.js %}
 {% asset app.js %}
 {% asset toc-subnav.js %}
 {% asset external-links.js %}

--- a/_layouts/report.html
+++ b/_layouts/report.html
@@ -15,7 +15,7 @@ layout: default
   <div class="grid-container">
     <div class="grid-row grid-gap">
 
-        
+
 
 
         <aside id="toc-aside" class="desktop:grid-col-3 margin-bottom-2 bg-white sticky">
@@ -44,7 +44,7 @@ layout: default
             </ul>
           </nav>
         </aside>
-        
+
 
 
 
@@ -53,7 +53,7 @@ layout: default
         {% if page.file %}
         <div class="clearfix">
             <span class="float-right">{{ page.file-description }}
-            <a href="{{ site.baseurl }}{{ page.file-directory }}{{ page.file }}" target="_blank">
+            <a href="{{ site.baseurl }}{{ page.file-directory }}{{ page.file }}" target="_blank" rel="noreferrer">
             <button class="usa-button ">Download</button>
             </a>
             </span>

--- a/_layouts/standards-enhanced.html
+++ b/_layouts/standards-enhanced.html
@@ -22,7 +22,7 @@ layout: default
         {% if page.file %}
         <div class="clearfix">
             <span class="float-right">{{ page.file-description }}
-            <a href="{{ site.baseurl }}{{ page.file-directory }}{{ page.file }}" target="_blank">
+            <a href="{{ site.baseurl }}{{ page.file-directory }}{{ page.file }}" target="_blank" rel="noreferrer">
             <button class="usa-button ">Download</button>
             </a>
             </span>

--- a/_layouts/standards.html
+++ b/_layouts/standards.html
@@ -21,7 +21,7 @@ layout: default
         {% if page.file %}
         <div class="clearfix">
             <span class="float-right">{{ page.file-description }}
-            <a href="{{ site.baseurl }}{{ page.file-directory }}{{ page.file }}" target="_blank">
+            <a href="{{ site.baseurl }}{{ page.file-directory }}{{ page.file }}" target="_blank" rel="noreferrer">
             <button class="usa-button">Download</button>
             </a>
             </span>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1547,6 +1547,11 @@
       "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
       "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg="
     },
+    "dompurify": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.0.14.tgz",
+      "integrity": "sha512-oqcjyCLHLjWugZ6VwK0YfmRND/DFy/CuZhdasmymMfnxbzaaQxBSA1ATZIXWESGDj/nvq1vKLmRa7rTdbGgrmQ=="
+    },
     "domready": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/domready/-/domready-1.0.8.tgz",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test": "bundle exec htmlproofer _site; npx a11y '_site/**/*.html'"
   },
   "dependencies": {
+    "dompurify": "^2.0.14",
     "jekyll": "^3.0.0-beta1",
     "netlify-cms": "^2.10.23",
     "stickyfilljs": "^2.1.0",

--- a/search/index.html
+++ b/search/index.html
@@ -8,15 +8,15 @@ title: Search
 <script>
 //<![CDATA[
 
-  var urlParams = new URLSearchParams(window.location.search);    
+  var urlParams = new URLSearchParams(window.location.search);
   var searchEndpoint = new URL("{{site.searchgov.endpoint}}/api/v2/search/i14y");
   params = { affiliate: "{{site.searchgov.affiliate}}", access_key: "{{site.searchgov.access_key}}", query: urlParams.get('query') }
-  
-  
+
+
   Object.keys(params).forEach(key => searchEndpoint.searchParams.append(key, params[key]))
 
-  fetch(searchEndpoint).then(function(response) {
-      return response.json()
+  fetch(searchEndpoint).then(function(result) {
+      return result.json()
     }).then(function(posts) {
       for (item in posts.web.results){
         render_result(`
@@ -25,18 +25,18 @@ title: Search
             <div> ${posts.web.results[item]['snippet'].replace(/\uE000/g, '<span class="bg-yellow">').replace(/\uE001/g, '</span>')} </div>
           </li>
           `, true)
-        
+
       }
     }).catch(function(ex) {
       console.log('parsing failed', ex);
     }).finally(function(e){
-    
+
       if(document.getElementById('search-results').childNodes.length == 0){
         render_result(`<h4 class="title">No results found</h4>`, false)
       }
-          
+
     })
-    
+
     function render_result(content, append = true){
       const previous = document.getElementById('search-results').innerHTML;
       document.getElementById('search-results').innerHTML = (append == true) ? previous + content : content;
@@ -56,14 +56,14 @@ title: Search
         This is an example. You will need to configure your site with search.gov to see the correct search results. To do this:
         <ol>
           <li>Create an account with Search.gov at <a href="https://search.usa.gov/signup">https://search.usa.gov/signup</a></li>
-          <li>Go to the "Activate" section and get "API Access Key"</a></li>          
+          <li>Go to the "Activate" section and get "API Access Key"</a></li>
           <li>Open <code>_config.yml</code> and look for <code>searchgov</code> fields</li>
           <li>Add your <code>affiliate</code> and <code>access_key</code></li>
-          <li>Your results will not show up immediately. Make sure you follow <a href="https://search.gov/manual/searchgov-for-federalist.html">instructions to index your site</a>.</li> 
+          <li>Your results will not show up immediately. Make sure you follow <a href="https://search.gov/manual/searchgov-for-federalist.html">instructions to index your site</a>.</li>
         </ol>
       </div>
     </div>
-  {% endif %}  
+  {% endif %}
 {% else %}
   <script>
     window.location = "/";


### PR DESCRIPTION
Initial scan from GSA had some minor alerts and added adjustments to mediate the initial scan results.

Acceptance Criteria:
- Sanitize inner html for the table of contents sections
- Change name of response variable to result on search page
- Add `rel='noreferrer'` to links with `target=_blank`