### PR TITLE
Fix missing subnav anchor text and reenable current anchor coloring

### DIFF
--- a/_assets/js/toc-subnav.js
+++ b/_assets/js/toc-subnav.js
@@ -4,8 +4,12 @@
   // Set page section anchors
   // TODO Add support for updating link anchor style on scroll
   // and page anchor change
-  function setPageSectionAnchors() {
+  function setPageSectionAnchors(event) {
     let elements;
+    let pageURL = event ? event.newURL : document.URL;
+    let urlParsed = pageURL.split('#');
+    let hasAnchor = urlParsed.length > 1;
+    let currentAnchor = hasAnchor ? urlParsed[urlParsed.length - 1] : null;
     let standard = document.getElementById("standard");
 
     if (standard) {
@@ -32,7 +36,13 @@
 
         let li = document.createElement("li");
         let a = document.createElement("a");
-        a.setAttribute("href", "\"#" + idtag + "\"");
+        a.setAttribute("href", "#" + idtag);
+        a.innerText = cleanedSection;
+
+        if (currentAnchor === idtag) {
+          a.className = "usa-current";
+        }
+
         li.appendChild(a);
 
         if (subsections) {
@@ -66,6 +76,8 @@
 
   // Set Anchors onload
   setPageSectionAnchors();
+  // Add event listener on window resize
+  window.addEventListener('hashchange', setPageSectionAnchors);
 
   // Set accordion onload
   setSubnav();


### PR DESCRIPTION
Fixes #375  the missing text in the table of contents h3 anchors.

[Preview URL](https://federalist-e3fba26d-2806-4f02-bf0e-89c97cfba93c.app.cloud.gov/preview/atbcb/usab-uswds/fix-subnav-anchors/ada/vehicles/)