### PR TITLE
change default table formatting

### DIFF
--- a/_assets/css/index.scss
+++ b/_assets/css/index.scss
@@ -29,6 +29,17 @@ h5, h6 { // default was xs and 2xs
 
 // Add your SASS/CSS here
 
+// unformated tables should pretty much look like they do in GitHub preview
+th, td {
+  border: thin solid black;
+}
+th {
+  background-color: gray-10;
+}
+tr:nth-child(even) {
+  background-color: gray-5;
+}
+
 // Page header USAB logo override
 .star-logo {
   height: 100%;
@@ -213,15 +224,6 @@ li.usa-nav__secondary-item a {
   display: table;
 }
 
-// we are avoiding layout tables
-table {
-  .usa-table { }
-}
-
-// add shading to even rows in data tables -- does not seem to be working
-table.data tr:nth-child(even) {
-  background-color: #f2f2f2;
-}
 //layout tables used in ict preamble
 table.layouttable {
   border-collapse: collapse;

--- a/_assets/css/index.scss
+++ b/_assets/css/index.scss
@@ -39,7 +39,7 @@ th {
   background-color: color(gray-cool-5);
 }
 tr:nth-child(even) {
-  .bg-gray-cool-10;
+  background-color: color(gray-cool-10);
 }
 
 // Page header USAB logo override

--- a/_assets/css/index.scss
+++ b/_assets/css/index.scss
@@ -213,6 +213,11 @@ li.usa-nav__secondary-item a {
   display: table;
 }
 
+// we are avoiding layout tables
+table {
+  .usa-table;
+}
+
 // add shading to even rows in data tables -- does not seem to be working
 table.data tr:nth-child(even) {
   background-color: #f2f2f2;

--- a/_assets/css/index.scss
+++ b/_assets/css/index.scss
@@ -215,7 +215,7 @@ li.usa-nav__secondary-item a {
 
 // we are avoiding layout tables
 table {
-  .usa-table
+  .usa-table { }
 }
 
 // add shading to even rows in data tables -- does not seem to be working

--- a/_assets/css/index.scss
+++ b/_assets/css/index.scss
@@ -215,7 +215,7 @@ li.usa-nav__secondary-item a {
 
 // we are avoiding layout tables
 table {
-  .usa-table;
+  .usa-table
 }
 
 // add shading to even rows in data tables -- does not seem to be working

--- a/_assets/css/index.scss
+++ b/_assets/css/index.scss
@@ -177,14 +177,14 @@ li.usa-nav__secondary-item a {
   @include u-margin(2);
 } // this closeing brace was missing !!
  
-&-box {
-//  &-box {
+/* &-box {
+  &-box {
     @extend .thumbnail;
     @include u-border(2px);
     @include u-radius('lg');
     @include u-padding(2);
-//  }
-}
+  }
+} */
 .thumbnail-wide {
   width: 15%;
   height: auto;

--- a/_assets/css/index.scss
+++ b/_assets/css/index.scss
@@ -201,7 +201,8 @@ li.usa-nav__secondary-item a {
 .clearfix {
   overflow: auto;
 }
-// sticky fill js .sticky {
+// sticky fill js
+.sticky {
   position: -webkit-sticky;
   position: sticky;
   top: 0;

--- a/_assets/css/index.scss
+++ b/_assets/css/index.scss
@@ -11,7 +11,7 @@
 
 $theme-hero-image: asset_path("hero-wc-temp.jpg");
 
-// Import the US Web Design System SASS.
+// Import the US Web Design System SASS
 @import "uswds";
 
 // Import component SASS
@@ -19,25 +19,25 @@ $theme-hero-image: asset_path("hero-wc-temp.jpg");
 @import "components/table-of-contents-subnav";
 
 // Set fonts
+
 h4 { // default was sm
-  @include u-font('sans', 'md')
+  @include u-font('sans', 'md');
 }
 h5, h6 { // default was xs and 2xs
-  @include u-font('sans', 'sm')
+  @include u-font('sans', 'sm');
 }
 
 // Add your SASS/CSS here
+
 // Page header USAB logo override
 .star-logo {
-height: 100%;
-width: 100%;
+  height: 100%;
+  width: 100%;
 }
-
 .site-title {
   font-weight: bold;
   @include u-text("primary-darker");
 }
-
 .site-subtitle {
   font-weight: bold;
   font-style: italic;
@@ -45,8 +45,8 @@ width: 100%;
 }
 
 @media screen and (max-width: 1024px) {
-  .site-logo {
-  max-height: 3rem;
+  site-logo {
+    max-height: 3rem;
   }
   .star-logo-box {
     max-height: 3rem;
@@ -56,10 +56,7 @@ width: 100%;
     max-height: 3rem;
   }
 }
-
-
 @media screen and (min-width: 1024px) {
-  
   .star-logo-box {
     max-width: 6rem;
   }
@@ -67,13 +64,11 @@ width: 100%;
     @include u-font('sans', 'md')
   }
 }
-
 @media (min-width: 30em) {
   .site-title-short {
-      display: none;
+     display: none;
   }
 }
-
 @media screen and (max-width: 29.99em) {
   .site-title {
     position: absolute;
@@ -81,36 +76,28 @@ width: 100%;
   }
 }
 
-
 /* .usa-logo__text::before {
   background-image: url(../images/usab-logo.svg);
   background-repeat: no-repeat;
 } */
 
-
-
-
-
 // override default gray to get 7:1 contrast ratio
 li.usa-nav__secondary-item a {
   color: #595959;
 }
-
 // temporary blue class to see how grids work
 .blue {
   background-color: blue;
 }
 
-// advisory boxes
+// advisory boxes, might be P or DIV
 .advisory {
   background-color: #e8f0f8;
   padding: 1em;
   margin-left: 1em;
   margin-right: 1em;
 }
-
 // create class that combines about page img classes
-
 .bold, dt {
   font-weight: bold;
 }
@@ -119,7 +106,6 @@ li.usa-nav__secondary-item a {
   margin-left: auto;
   margin-right: auto;
 }
-
 .img-right {
   float: right;
   display: block;
@@ -160,9 +146,7 @@ li.usa-nav__secondary-item a {
   display: block;
   text-align: left;
 }
-
-/* replace grid-line-left with text-left display-block instead */
-
+// replace grid-line-left with text-left display-block instead
 .img-large {
   padding: 10px;
   margin-left: auto;
@@ -170,7 +154,6 @@ li.usa-nav__secondary-item a {
   width: 80%;
   display: block;
 }
-
 .img-large-caption {
   margin: auto;
   text-align: center;
@@ -178,7 +161,6 @@ li.usa-nav__secondary-item a {
   font-size: 90%;
   font-style: italic;
 }
-
 .img-full {
   padding: 10px;
   margin-left: auto;
@@ -186,7 +168,6 @@ li.usa-nav__secondary-item a {
   width: 100%;
   display: block;
 }
-
 .thumbnail {
   width: 15%;
   height: auto;
@@ -194,7 +175,8 @@ li.usa-nav__secondary-item a {
   //vertical-align: 30%;
   //max-height: 100px;
   @include u-margin(2);
-
+} // this closeing brace was missing !!
+ 
 &-box {
   &-box {
     @extend .thumbnail;
@@ -203,52 +185,47 @@ li.usa-nav__secondary-item a {
     @include u-padding(2);
   }
 }
-
 .thumbnail-wide {
   width: 15%;
   height: auto;
 }
-
 .align-bottom {
   vertical-align: text-bottom;
 }
 .align-top {
   vertical-align: text-top;
 }
-
 .clear {
   clear: both;
 }
 .clearfix {
   overflow: auto;
 }
-
-// sticky fill js
-.sticky {
+// sticky fill js .sticky {
   position: -webkit-sticky;
   position: sticky;
   top: 0;
 }
-
 .sticky:before,
 .sticky:after {
-    content: '';
-    display: table;
+  content: '';
+  display: table;
 }
 
-//add shading to even rows in data tables
-table.data tr:nth-child(even) {background-color: #f2f2f2;}
-
+// add shading to even rows in data tables -- does not seem to be working
+table.data tr:nth-child(even) {
+  background-color: #f2f2f2;
+}
 //layout tables used in ict preamble
 table.layouttable {
   border-collapse: collapse;
 }
-
-table.layouttable, table.layouttable tr {
+table.layouttable,
+table.layouttable tr {
   border: 1px solid black;
 }
 
-//doesn't seem to work; added style to include figure-caption.html
+// doesn't seem to work; added style to include figure-caption.html
 figcaption {
   font-weight: bold;
   text-align: center;
@@ -271,7 +248,6 @@ a.usa-current::after {
     float: left;
   }
 }
-
 @media screen and (min-width: 640px) {
   .paginate-link {
     display: initial;
@@ -280,7 +256,6 @@ a.usa-current::after {
     display: none;
   }
 }
-
 @media screen and (max-width: 640px) {
   .paginate-link {
     display: none;
@@ -289,8 +264,7 @@ a.usa-current::after {
     display: block;
   }
 }
-} // extra closing brace ???
-
+// } extra closing brace was here !!
 .card-header {
   @extend .usa-card__header;
   text-align: center;
@@ -309,7 +283,7 @@ a.usa-current::after {
   @include u-bg('primary-lighter')
 }
 
- a.style-inherit {
+a.style-inherit {
   color: inherit; /* blue colors for links too */
   text-decoration: inherit; /* no underline */
 }

--- a/_assets/css/index.scss
+++ b/_assets/css/index.scss
@@ -178,12 +178,12 @@ li.usa-nav__secondary-item a {
 } // this closeing brace was missing !!
  
 &-box {
-  &-box {
+//  &-box {
     @extend .thumbnail;
     @include u-border(2px);
     @include u-radius('lg');
     @include u-padding(2);
-  }
+//  }
 }
 .thumbnail-wide {
   width: 15%;

--- a/_assets/css/index.scss
+++ b/_assets/css/index.scss
@@ -31,15 +31,17 @@ h6 { // default was xs and 2xs
 // unformated tables should look more like they do in GitHub preview
 th,
 td {
+  margin:0;
+  border: 1px solid black;
   border-collapse: collapse;
-  border: thin solid black;
   vertical-align: top;
+  padding-left:1em;
 }
 th {
-  background-color: color(gray-cool-5);
+  background-color: color(gray-cool-10);
 }
 tr:nth-child(even) {
-  background-color: color(gray-cool-10);
+  background-color: color(gray-cool-5);
 }
 
 // Page header USAB logo override
@@ -223,10 +225,10 @@ dt {
   display: table;
 }
 
-// add shading to even rows in data tables -- does not seem to be working
+/* // add shading to even rows in data tables -- does not seem to be working
 table.data tr:nth-child(even) {
  background-color: #f2f2f2;
-}
+} // zebra stripping by default */
 // layout tables used in ict preamble
 table.layouttable {
   border-collapse: collapse;

--- a/_assets/css/index.scss
+++ b/_assets/css/index.scss
@@ -29,6 +29,10 @@ h6 { // default was xs and 2xs
 
 // Add your SASS/CSS here
 // unformated tables should look more like they do in GitHub preview
+table {
+  margin-top:1em;
+  margin-bottom:1em;
+}
 th,
 td {
   margin:0;

--- a/_assets/css/index.scss
+++ b/_assets/css/index.scss
@@ -44,10 +44,13 @@ table, thead, tbody, tr, th, td {
 td {
   border: thin solid black;
   vertical-align: top;
-  padding-left:1em;
+  padding-left:0.5em;
+  padding-right:0.25em;
 }
 th {
   background-color: color(gray-cool-10);
+  border: thin solid black;
+  padding-left:0.25em;
 }
 tr:nth-child(even) {
   background-color: color(gray-cool-5);

--- a/_assets/css/index.scss
+++ b/_assets/css/index.scss
@@ -61,7 +61,7 @@ h5, h6 { // default was xs and 2xs
     max-width: 6rem;
   }
   .site-subtitle {
-    @include u-font('sans', 'md')
+    @include u-font('sans', 'md');
   }
 }
 @media (min-width: 30em) {
@@ -281,12 +281,12 @@ a.usa-current::after {
 .gray-to-color:hover {
   -webkit-filter: none;
   filter: none;
-  @include u-bg('primary-lighter')
+  @include u-bg('primary-lighter');
 }
 
 a.style-inherit {
-  color: inherit; /* blue colors for links too */
-  text-decoration: inherit; /* no underline */
+  color: inherit; // blue colors for links too
+  text-decoration: inherit; // no underline
 }
 
 .card-name {

--- a/_assets/css/index.scss
+++ b/_assets/css/index.scss
@@ -28,16 +28,21 @@ h6 { // default was xs and 2xs
 }
 
 // Add your SASS/CSS here
+
+a.usa-current::after {
+  content: "→" !important;
+}
+
 // unformated tables should look more like they do in GitHub preview
 table {
   margin-top:1em;
   margin-bottom:1em;
 }
-th,
-td {
-  margin:0;
-  border: 1px solid black;
+table, thead, tbody, tr, th, td {
   border-collapse: collapse;
+}
+td {
+  border: thin solid black;
   vertical-align: top;
   padding-left:1em;
 }
@@ -93,61 +98,71 @@ tr:nth-child(even) {
     left: -999em;
   }
 }
+
 /* .usa-logo__text::before {
   background-image: url(../images/usab-logo.svg);
   background-repeat: no-repeat;
 } */
 
-// override default gray to get 7:1 contrast ratio
+// override default gray to get a little higher contrast
 li.usa-nav__secondary-item a {
-  color: #595959;
+  color: color(gray-cool-60);
 }
 // temporary blue class to see how grids work
 .blue {
   background-color: blue;
 }
+
 // advisory boxes, might be P or DIV
 .advisory {
-  background-color: #e8f0f8;
+  background-color: color(blue-warm-20);
   padding: 1em;
   margin-left: 1em;
   margin-right: 1em;
 }
+
 // create class that combines about page img classes
 .bold,
 dt {
   font-weight: bold;
 }
+
 .center {
   display: block;
   margin-left: auto;
   margin-right: auto;
 }
+
 .img-right {
   float: right;
   display: block;
   padding: 15px;
 }
+
 .img-left {
   float: left;
   display: block;
   padding: 15px;
 }
+
 .img-medium {
   padding: 10px;
   width: 40%;
 }
+
 .img-center {
   margin-left: auto;
   margin-right: auto;
   display: block;
 }
+
 .img-grid {
   margin-left: auto;
   margin-right: auto;
   width: 50%;
   display: block;
 }
+
 .img-grid-left {
   margin-left: auto;
   margin-right: auto;
@@ -155,14 +170,17 @@ dt {
   display: block;
   padding-top: 20px;
 }
+
 .grid-line {
   display: block;
   text-align: center;
 }
+
 .grid-line-left {
   display: block;
   text-align: left;
 }
+
 // replace grid-line-left with text-left display-block instead
 .img-large {
   padding: 10px;
@@ -171,6 +189,7 @@ dt {
   width: 80%;
   display: block;
 }
+
 .img-large-caption {
   margin: auto;
   text-align: center;
@@ -178,6 +197,7 @@ dt {
   font-size: 90%;
   font-style: italic;
 }
+
 .img-full {
   padding: 10px;
   margin-left: auto;
@@ -185,6 +205,7 @@ dt {
   width: 100%;
   display: block;
 }
+
 .thumbnail {
   width: 15%;
   height: auto;
@@ -201,28 +222,35 @@ dt {
     }
   }
 }
+
 .thumbnail-wide {
   width: 15%;
   height: auto;
 }
+
 .align-bottom {
   vertical-align: text-bottom;
 }
+
 .align-top {
   vertical-align: text-top;
 }
+
 .clear {
   clear: both;
 }
+
 .clearfix {
   overflow: auto;
 }
+
 // sticky fill js
 .sticky {
   position: -webkit-sticky;
   position: sticky;
   top: 0;
 }
+
 .sticky:before,
 .sticky:after {
   content: '';
@@ -241,18 +269,18 @@ table.layouttable,
 table.layouttable tr {
   border: 1px solid black;
 }
+
 // doesn't seem to work; added style to include figure-caption.html
 figcaption {
   font-weight: bold;
   text-align: center;
 }
-a.usa-current::after {
-  content: "→" !important;
-}
+
 // default mode hide banner
 .usa-banner__content {
   display: hidden;
 }
+
 @media screen and (min-width: 640px) {
   .tablet\:width-1\/3 {
     width: 33%;
@@ -261,6 +289,7 @@ a.usa-current::after {
     float: left;
   }
 }
+
 @media screen and (min-width: 640px) {
   .paginate-link {
     display: initial;
@@ -269,6 +298,7 @@ a.usa-current::after {
     display: none;
   }
 }
+
 @media screen and (max-width: 640px) {
   .paginate-link {
   display: none;
@@ -285,25 +315,30 @@ a.usa-current::after {
   @include u-text('white');
   padding: 1rem;
 }
+
 .gray-to-color {
   -webkit-filter: grayscale(100%);
   filter: grayscale(100%);
 }
+
 .gray-to-color:hover {
   -webkit-filter: none;
   filter: none;
   @include u-bg('primary-lighter')
 }
+
 a.style-inherit {
   color: inherit; // blue colors for links too
   text-decoration: inherit; // no underline
 }
+
 .card-name {
   @include u-font('serif', '2xs');
   @include u-text('center');
   @include u-text('primary');
   @include u-margin-bottom(0);
 }
+
 .card-text {
   @include u-font('serif', '3xs');
   @include u-text('center');

--- a/_assets/css/index.scss
+++ b/_assets/css/index.scss
@@ -28,6 +28,19 @@ h6 { // default was xs and 2xs
 }
 
 // Add your SASS/CSS here
+// unformated tables should look more like they do in GitHub preview
+th,
+td {
+  border-collapse: collapse;
+  border: thin solid black;
+  vertical-align: top;
+}
+th {
+  background-color: color(gray-cool-5);
+}
+tr:nth-child(even) {
+  .bg-gray-cool-10;
+}
 
 // Page header USAB logo override
 .star-logo {
@@ -181,7 +194,7 @@ dt {
       @include u-padding(2);
     }
   }
-} // this brace was missing previously, was at line 259 below
+}
 .thumbnail-wide {
   width: 15%;
   height: auto;
@@ -204,7 +217,8 @@ dt {
   position: sticky;
   top: 0;
 }
-.sticky:before, .sticky:after {
+.sticky:before,
+.sticky:after {
   content: '';
   display: table;
 }
@@ -217,7 +231,8 @@ table.data tr:nth-child(even) {
 table.layouttable {
   border-collapse: collapse;
 }
-table.layouttable, table.layouttable tr {
+table.layouttable,
+table.layouttable tr {
   border: 1px solid black;
 }
 // doesn't seem to work; added style to include figure-caption.html
@@ -256,7 +271,7 @@ a.usa-current::after {
   display: block;
   }
 }
-// } extra closing brace was here !!
+
 .card-header {
   @extend .usa-card__header;
   text-align: center;

--- a/_pages/contact.md
+++ b/_pages/contact.md
@@ -27,7 +27,6 @@ If you have questions on these accessibility guidelines and standards call or em
 
 *Technical assistance is available 10:00 -- 5:00 ET weekdays.*
 
-
 ## E-mail Directory
 
 | contact us at... | for... |

--- a/_pages/contact.md
+++ b/_pages/contact.md
@@ -50,12 +50,12 @@ If you have questions on these accessibility guidelines and standards call or em
 ***tty:***  **202-272-0082** or **800-993-2822**
 
 |Executive Director's Office | &nbsp; | &nbsp; |
-| --- | --- | --- |
+|:--- | --- | --- |
 | Gretchen Jacobs, Acting Executive Director | 202-272-0040 (v) | 202-272-0075 (tty) |
 | Rose Marie Bunales | 202-272-0006 (v) | 202-272-0057 (tty) |
 
 |Office of Administration | &nbsp; | &nbsp; |
-| --- | --- | --- |
+|:--- | --- | --- |
 | Earlene Sesker, Director | 202-272-0022 (v) | 202-272-0091 (tty) |
 | Edson Carneiro | 202-272-0008 (v) | 202-272-0077 (tty) |
 | Gainna Ellis | 202-272-0007 (v) | 202-272-0058 (tty) |
@@ -65,13 +65,13 @@ If you have questions on these accessibility guidelines and standards call or em
 | Charles Washington | 202-272-0005 (v) | 202-272-0061 (tty) |
 | Jianhao Zhen | 202-272-0002 (v) | 202-272-0052 (tty) |
 
-|Public Affairs | &nbsp; | &nbsp; |
-| --- | --- | --- |
-|Phil Bratta | 202-272-0012 (v) | 202-272-0072 (tty) |
+| Public Affairs | &nbsp; | &nbsp; |
+|:--- | --- | --- |
+| Phil Bratta | 202-272-0012 (v) | 202-272-0072 (tty) |
 
-|Technical and Information Services | &nbsp; | &nbsp; |
-| --- | --- | --- |
-| Dave Yanchulis, Director  | 202-272-0026 (v) | 202-272-0027 (tty) |
+| Technical and Information Services | &nbsp; | &nbsp; |
+|:--- | --- | --- |
+| Dave Yanchulis, Director | 202-272-0026 (v) | 202-272-0027 (tty) |
 | Bruce Bailey | 202-272-0024 (v) | 202-272-0070 (tty) |
 | William Botten | 202-272-0014 (v) | 202-272-0073 (tty) |
 | Phil Bratta | 202-272-0012 (v) | 202-272-0072 (tty) |
@@ -84,8 +84,8 @@ If you have questions on these accessibility guidelines and standards call or em
 | Bobby Stinnette | 202-272-0021 (v) | 202-272-0049 (tty) |
 | Scott Windley | 202-272-0025 (v) | 202-272-0028 (tty) |
 
-|Office of the General Counsel | &nbsp; | &nbsp; |
-| --- | --- | --- |
+| Office of the General Counsel | &nbsp; | &nbsp; |
+|:--- | --- | --- |
 | Gretchen Jacobs, General Counsel | 202-272-0040 (v) | 202-272-0075 (tty) |
 | Mario Damiani | 202-272-0050 (v) | 202-272-0066 (tty) |
 | Christopher Kuczynski | 202-272-0042 (v) | 202-272-0076 (tty) |


### PR DESCRIPTION
When people have a table, they expect it to look like tables do in GitHub Preview.

If a table is used for layout, the table should use an explicit class for that.