### PR TITLE
Set initial state to hidden for banner and menu nav

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -23,7 +23,7 @@ This appears at the top of the page letting the user know it's an official gover
           </button>
         </div>
       </header>
-      <div class="usa-banner__content usa-accordion__content" id="gov-banner">
+      <div class="usa-banner__content usa-accordion__content" id="gov-banner" hidden>
         <div class="grid-row grid-gap-lg">
           <div class="usa-banner__guidance tablet:grid-col-6">
             {% asset icon-dot-gov.svg class="usa-banner__icon usa-media-block__img" alt="Dot gov" %}

--- a/_includes/menu.html
+++ b/_includes/menu.html
@@ -24,7 +24,7 @@ where we provide an easy way to manage your navigation system
         {% assign nav_id = 'primary-nav-' | append: forloop.index %}
         <li class="usa-nav__primary-item">
           <button class="usa-accordion__button usa-nav__link" aria-expanded="false"
-            aria-controls="{{ nav_id }}"><span>{{ nav_item.name | escape }}</span></button>
+            aria-controls="{{ nav_id }}" hidden><span>{{ nav_item.name | escape }}</span></button>
           <ul id="{{ nav_id }}" class="usa-nav__submenu">
             {% for subnav_item in nav_item.children %}
             <li class="usa-nav__submenu-item">


### PR DESCRIPTION
Make sure the US Gov website banner and the multi select nav dropdown are closed by default.