### PR TITLE
Initial examples of redirecting from and to pages

### DIFF
--- a/_ada/ada-standards.html
+++ b/_ada/ada-standards.html
@@ -7,6 +7,9 @@ order-number: 1
 image-directory: /images/ada-aba/standards/
 file: ADA-Standards.pdf
 file-description: Single file PDF version of the ADA Standards
+redirect_from:
+    - /guidelines-and-standards/buildings-and-sites/about-the-ada-standards/ada-standards
+    - /guidelines-and-standards/buildings-and-sites/about-the-ada-standards/ada-standards/single-file-version
 ---
 
 {% assign ada-chapters = site.ada | where: "title","About the ADA" %}

--- a/_config.yml
+++ b/_config.yml
@@ -176,6 +176,8 @@ collections:
     output: false
   contacts-504:
     output: false
+  redirect-tos:
+    output: true
 
 permalink: pretty
 

--- a/_redirect-tos/ada-guidelines-and-standards-ch-6.md
+++ b/_redirect-tos/ada-guidelines-and-standards-ch-6.md
@@ -1,0 +1,4 @@
+---
+permalink: /guidelines-and-standards/buildings-and-sites/about-the-ada-standards/ada-standards/chapter-6-plumbing-elements-and-facilities
+redirect_to: /ada/#a6
+---

--- a/_redirect-tos/ada-guidelines-and-standards-ch-7.md
+++ b/_redirect-tos/ada-guidelines-and-standards-ch-7.md
@@ -1,0 +1,4 @@
+---
+permalink: /guidelines-and-standards/buildings-and-sites/about-the-ada-standards/ada-standards/chapter-7-communication-elements-and-features
+redirect_to: /ada/#a7
+---


### PR DESCRIPTION
Added the `_redirect-tos` collection to show how you can redirect from a permalink of the old page to the new page with `#` anchor to identify the subheading on the page. Also the `redirect_from` added to a page when many old pages can point to the new one.  Note that the `redirect_from` cannot interpret the anchor `#`.