### PR TITLE
Add resources section to ICT landing page

### DIFF
--- a/_assets/css/index.scss
+++ b/_assets/css/index.scss
@@ -59,12 +59,6 @@ a.usa-current::after {
   content: "→" !important;
 }
 
-// default to have images float to right (and text wrap left)
-#content > p > img {
-  display:block;
-  float:right;
-}
-
 fieldset {
   border: thin solid color(primary-darker);
 }

--- a/_ict/about.md
+++ b/_ict/about.md
@@ -15,9 +15,9 @@ The Section 255 Guidelines cover telecommunications equipment and customer-premi
 
 ### Background
 
-* February 3, 1998 - The Board publishes the original [Telecommunications Act Accessibility Guidelines](https://www.federalregister.gov/d/98-2414).
-* December 21, 2000 - The Board issues the original [Section 508 Standards](https://www.federalregister.gov/d/E6-10562).
-* July 6, 2006 - The Board [organizes TEITAC](https://federalregister.gov/d/E6-10562), the Telecommunications and Electronic and Information Technology Advisory Committee to assist in updating the Section 508 Standards and Telecommunications Act Guidelines.
+* February 3, 1998 - The Board publishes the [original Telecommunications Act Accessibility Guidelines](https://federalregister.gov/d/98-2414).
+* December 21, 2000 - The Board issues the [original Section 508 Standards](https://federalregister.gov/d/E6-10562).
+* July 6, 2006 - The [Board organizes TEITAC](https://federalregister.gov/d/E6-10562), the Telecommunications and Electronic and Information Technology Advisory Committee, to assist in updating the Section 508 Standards and Telecommunications Act Guidelines.
 * April 3, 2008 - The Advisory Committee presents its final report to the Board.
 * March 22, 2010 - The Board releases a [draft proposed rule](https://federalregister.gov/d/2010-6245) for public comment, [beta docket ATBCB-2010-0001](https://beta.regulations.gov/docket/ATBCB-2010-0001).
 * December 8, 2011 - The Board issues a [revised draft proposed rule](https://federalregister.gov/d/2011-31462) for public comment, [beta docket ATBCB-2011-0007](https://beta.regulations.gov/docket/ATBCB-2011-0007).

--- a/_ict/about.md
+++ b/_ict/about.md
@@ -7,7 +7,6 @@ redirect_from:
     - /guidelines-and-standards/communications-and-it/about-the-ict-refresh/
     - /guidelines-and-standards/communications-and-it/about-the-section-508-standards/
 ---
-
 These standards address access to information and communication technology (ICT) under Section 508 of the Rehabilitation Act and Section 255 of the Communications Act. 
 
 Section 508 requires access to ICT developed, procured, maintained, or used by federal agencies.  Examples include computers, telecommunications equipment, multifunction office machines such as copiers that also operate as printers, software, websites, information kiosks and transaction machines, and electronic documents.  The Section 508 Standards, which are part of the Federal Acquisition Regulation, ensure access for people with physical, sensory, or cognitive disabilities.
@@ -20,8 +19,8 @@ The Section 255 Guidelines cover telecommunications equipment and customer-premi
 * December 21, 2000 - The Board issues the original [Section 508 Standards](https://www.federalregister.gov/d/E6-10562).
 * July 6, 2006 - The Board [organizes](https://www.federalregister.gov/d/E6-10562) the Telecommunications and Electronic and Information Technology Advisory Committee to assist in updating the Section 508 Standards and Telecommunications Act Guidelines.
 * April 3, 2008 - The Advisory Committee presents its final report to the Board.
-* March 22, 2010 - The Board releases a [draft proposed rule](https://www.regulations.gov/document?D=ATBCB-2010-0001-0002) for public comment: [Docket](https://www.regulations.gov/docket?D=ATBCB-2010-0001).
-* December 8, 2011 - The Board issues a [revised draft proposed rule](https://www.regulations.gov/document?D=ATBCB-2011-0007-0001) for public comment: [Docket](https://www.regulations.gov/docket?D=ATBCB-2011-0007).
-* February 23, 2014 - The Board [ICT proposed rule](https://www.regulations.gov/document?D=ATBCB-2015-0002-0001) for public comment: [Docket](https://www.regulations.gov/docket?D=ATBCB-2015-0002).
-* January 18, 2017 - The Board issues the [final rule](https://www.regulations.gov/document?D=ATBCB-2015-0002-0144).
-* January 22, 2018 - The Board issues [correction](https://www.regulations.gov/document?D=ATBCB-2015-0002-0146) to the final rule to restore provisions for TTY access. 
+* March 22, 2010 - The Board releases a [draft proposed rule](https://www.regulations.gov/document?D=ATBCB-2010-0001-0002) for public comment, [docket ATBCB-2010-0001](https://www.regulations.gov/docket/ATBCB-2010-0001).
+* December 8, 2011 - The Board issues a [revised draft proposed rule](https://www.regulations.gov/document?D=ATBCB-2011-0007-0001) for public comment, [docket ATBCB-2011-0007](https://www.regulations.gov/docket/ATBCB-2011-0007).
+* February 23, 2014 - The Board [ICT proposed rule](https://www.regulations.gov/document?D=ATBCB-2015-0002-0001) for public comment, [docket ATBCB-2015-0002](https://www.regulations.gov/docket/ATBCB-2015-0002).
+* January 18, 2017 - The Board issues the [final rule](https://www.regulations.gov/document?D=ATBCB-2015-0002-0144), [ATBCB-2015-0002-014](https://beta.regulations.gov/document/ATBCB-2015-0002-0144).
+* January 22, 2018 - The Board issues [correction](https://www.regulations.gov/document?D=ATBCB-2015-0002-0146) to the final rule to restore provisions for TTY access,  [ATBCB-2015-0002-0146](https://beta.regulations.gov/document/ATBCB-2015-0002-0146).

--- a/_ict/about.md
+++ b/_ict/about.md
@@ -13,14 +13,19 @@ Section 508 requires access to ICT developed, procured, maintained, or used by f
 
 The Section 255 Guidelines cover telecommunications equipment and customer-premises equipment---such as telephones, cell phones, routers, set-top boxes, and computers with modems, interconnected Voice over Internet Protocol products, and software integral to the operation of telecommunications function of such equipment.
 
-## Background
+### Background
 
 * February 3, 1998 - The Board publishes the original [Telecommunications Act Accessibility Guidelines](https://www.federalregister.gov/d/98-2414).
 * December 21, 2000 - The Board issues the original [Section 508 Standards](https://www.federalregister.gov/d/E6-10562).
-* July 6, 2006 - The Board [organizes](https://www.federalregister.gov/d/E6-10562) the Telecommunications and Electronic and Information Technology Advisory Committee to assist in updating the Section 508 Standards and Telecommunications Act Guidelines.
+* July 6, 2006 - The Board [organizes TEITAC](https://federalregister.gov/d/E6-10562), the Telecommunications and Electronic and Information Technology Advisory Committee to assist in updating the Section 508 Standards and Telecommunications Act Guidelines.
 * April 3, 2008 - The Advisory Committee presents its final report to the Board.
-* March 22, 2010 - The Board releases a [draft proposed rule](https://www.regulations.gov/document?D=ATBCB-2010-0001-0002) for public comment, [docket ATBCB-2010-0001](https://www.regulations.gov/docket/ATBCB-2010-0001).
-* December 8, 2011 - The Board issues a [revised draft proposed rule](https://www.regulations.gov/document?D=ATBCB-2011-0007-0001) for public comment, [docket ATBCB-2011-0007](https://www.regulations.gov/docket/ATBCB-2011-0007).
-* February 23, 2014 - The Board [ICT proposed rule](https://www.regulations.gov/document?D=ATBCB-2015-0002-0001) for public comment, [docket ATBCB-2015-0002](https://www.regulations.gov/docket/ATBCB-2015-0002).
-* January 18, 2017 - The Board issues the [final rule](https://www.regulations.gov/document?D=ATBCB-2015-0002-0144), [ATBCB-2015-0002-014](https://beta.regulations.gov/document/ATBCB-2015-0002-0144).
-* January 22, 2018 - The Board issues [correction](https://www.regulations.gov/document?D=ATBCB-2015-0002-0146) to the final rule to restore provisions for TTY access,  [ATBCB-2015-0002-0146](https://beta.regulations.gov/document/ATBCB-2015-0002-0146).
+* March 22, 2010 - The Board releases a [draft proposed rule](https://federalregister.gov/d/2010-6245) for public comment, [beta docket ATBCB-2010-0001](https://beta.regulations.gov/docket/ATBCB-2010-0001).
+* December 8, 2011 - The Board issues a [revised draft proposed rule](https://federalregister.gov/d/2011-31462) for public comment, [beta docket ATBCB-2011-0007](https://beta.regulations.gov/docket/ATBCB-2011-0007).
+* February 27, 2015 - The Board [ICT proposed rule](https://federalregister.gov/d/2015-03467) for public comment, [beta docket ATBCB-2015-0002](https://beta.regulations.gov/docket/ATBCB-2015-0002).
+* January 18, 2017 - The Board issues the [final rule](https://federalregister.gov/d/2017-00395), [beta docket ATBCB-2015-0002-014](https://beta.regulations.gov/document/ATBCB-2015-0002-0144).
+* January 22, 2018 - The Board issues [correctionto the final rule](https://federalregister.gov/d/2018-00848) to restore provisions for TTY access, [beta docket ATBCB-2015-0002-0146](https://beta.regulations.gov/document/ATBCB-2015-0002-0146).
+
+### Additional Resources
+
+* Final Regulatory Impact Analysis ([FRIA]({{ site.baseurl }}/ict/fria.html))
+* [Comparison Table of WCAG 2.0 to Existing 508 Standards]({{ site.baseurl }}/ict/wcag2ict.html)

--- a/_pages/about/budget-performance/par.md
+++ b/_pages/about/budget-performance/par.md
@@ -40,7 +40,7 @@ permalink: /about/par.html
 <p>I am pleased to present the Access Board's Performance and Accountability Report for Fiscal Year 2019. This report provides key information on the Access Board's progress in meeting its mission and managing its financial responsibilities. Our agency has a proud history of serving the public through its programs devoted to accessibility for people with disabilities.</p>
 <p>Fiscal Year 2019 was a year of continued success. The Access Board continues to develop accessibility requirements, provide technical assistance and training, and enforce access requirements for the Federal government. We will continue to strive for excellence to fulfill our responsibilities to provide accessibility for people with disabilities.</p>
 <p>Sincerely,</p>
-<p><img src="{{ site.baseurl }}/images/capozzi-signature.jpg" alt="David Capozzi signature" class="img-left" /></p>
+<p><img src="{{ site.baseurl }}/images/capozzi-signature.jpg" alt="David Capozzi signature" /></p>
 <p>David M. Capozzi<br />
   Executive Director</p>
 <hr />

--- a/_pages/about/budget-performance/par.md
+++ b/_pages/about/budget-performance/par.md
@@ -40,7 +40,7 @@ permalink: /about/par.html
 <p>I am pleased to present the Access Board's Performance and Accountability Report for Fiscal Year 2019. This report provides key information on the Access Board's progress in meeting its mission and managing its financial responsibilities. Our agency has a proud history of serving the public through its programs devoted to accessibility for people with disabilities.</p>
 <p>Fiscal Year 2019 was a year of continued success. The Access Board continues to develop accessibility requirements, provide technical assistance and training, and enforce access requirements for the Federal government. We will continue to strive for excellence to fulfill our responsibilities to provide accessibility for people with disabilities.</p>
 <p>Sincerely,</p>
-<p><img src="{{ site.baseurl }}/images/capozzi-signature.jpg" alt="David Capozzi signature" /></p>
+<p><img src="{{ site.baseurl }}/images/capozzi-signature.jpg" alt="David Capozzi signature" class="img-left" /></p>
 <p>David M. Capozzi<br />
   Executive Director</p>
 <hr />

--- a/_pages/highlights/ict.md
+++ b/_pages/highlights/ict.md
@@ -76,4 +76,4 @@ On January 18, 2017, the Board published a final rule that updates the Section 2
 
 #### Orginal Section 255 Guidelins (1998)
 
-The original Telecommunication Act Section 255 Accessibility Guidelines (February 3, 1998) can be found in older editions of the Code of Federal Regulations as [36 CFR 1193](https://www.govinfo.gov/content/pkg/CFR-2016-title36-vol3/pdf/CFR-2016-title36-vol3-part1193.pdf). {% asset pdf.gif alt="PDF icon" class="img-left" %}
+The original Telecommunication Act Section 255 Accessibility Guidelines (February 3, 1998) can be found in older editions of the Code of Federal Regulations as [36 CFR 1193](https://www.govinfo.gov/content/pkg/CFR-2016-title36-vol3/pdf/CFR-2016-title36-vol3-part1193.pdf). {% asset pdf.gif alt="PDF icon" %}

--- a/_pages/highlights/ict.md
+++ b/_pages/highlights/ict.md
@@ -1,10 +1,9 @@
 ---
-title: Communications and Information Technology
+title: Information and Communication Technology
 layout: page
 sidenav: false
 permalink: /ict.html
 ---
-
 {% asset stock/ict.jpg class="img-right shadow radius-lg" alt="photo of hands typing on braille keyboard" %}
 
 Access to information and communication technology (ICT) is addressed by Board standards and guidelines issued under Section 508 of the Rehabilitation Act and Section 255 of the Communications Act.
@@ -77,5 +76,4 @@ On January 18, 2017, the Board published a final rule that updates the Section 2
 
 #### Orginal Section 255 Guidelins (1998)
 
-The original Telecommunication Act Section 255 Accessibility Guidelines (February 3, 1998) can be found in older editions of the Code of Federal Regulations as [36 CFR 1193](https://www.govinfo.gov/content/pkg/CFR-2016-title36-vol3/pdf/CFR-2016-title36-vol3-part1193.pdf).
-{% asset pdf.gif alt="PDF icon" class="img.left" %}
+The original Telecommunication Act Section 255 Accessibility Guidelines (February 3, 1998) can be found in older editions of the Code of Federal Regulations as [36 CFR 1193](https://www.govinfo.gov/content/pkg/CFR-2016-title36-vol3/pdf/CFR-2016-title36-vol3-part1193.pdf). {% asset pdf.gif alt="PDF icon" class="img-left" %}

--- a/_pages/highlights/readme.md
+++ b/_pages/highlights/readme.md
@@ -1,0 +1,1 @@
+This folder contains landing pages from the homepage for categories that need them.

--- a/_pages/readme.md
+++ b/_pages/readme.md
@@ -1,0 +1,3 @@
+This directory contains stand-alone pages from the About menu and elsewhere.
+- Most pages are grouped under sub folders.
+- Landing pages from the home page are in the highlights folder


### PR DESCRIPTION
- Making link text in ICT landing page more descriptive.
- Add resource section to ICT landing page.
- Revert CSS change that has images floating to right.