### PR TITLE
removed navigation links at top of major sections

### DIFF
--- a/_ict/preamble.html
+++ b/_ict/preamble.html
@@ -3,7 +3,6 @@ title: "Preamble to the Final Rule"
 permalink: /ict/preamble.html
 version: original
 ---
-
 <div itemprop="articleBody">
   <h2 id="preamble">Preamble to the Final Rule</h2>
   <p>Published in the <a href="https://federalregister.gov/d/2017-00395">Federal Register</a> on January 18, 2017 and <a
@@ -20,25 +19,20 @@ version: original
     255 of the Communications Act of 1934. The revisions and updates to the section 508-based standards and section
     255-based guidelines are intended to ensure that information and communication technology covered by the respective
     statutes is accessible to and usable by individuals with disabilities.</p>
-  <p><strong>DATE:</strong> This final rule is effective March 20, 2017. [<em>Note</em>: The Board changed the effective
+  <p><strong>DATE:</strong>&nbsp; This final rule is effective March 20, 2017. [<em>Note</em>: The Board changed the effective
     date to March 21, 2017, as indicated in a <a href="https://federalregister.gov/d/2017-04059">notice</a> published on
     March 2, 2017.] However, compliance with the section 508-based standards is not required until January 18, 2018.
     Compliance with the section 255-based guidelines is not required until the guidelines are adopted by the Federal
     Communications Commission. The incorporation by reference of certain publications listed in the final rule is
     approved by the Director of the Federal Register as of March 20, 2017.</p>
-  <p><strong>FOR FURTHER INFORMATION CONTACT:</strong> Timothy Creagan, Access Board, 1331 F Street, NW, Suite 1000,
+  <p><strong>FOR FURTHER INFORMATION CONTACT:</strong>&nbsp; Timothy Creagan, Access Board, 1331 F Street NW, Suite 1000,
     Washington, DC 20004–1111. Telephone: (202) 272–0016 (voice) or (202) 272–0074 (TTY). Or Bruce Bailey, Access Board,
     1331 F Street, NW, Suite 1000, Washington, DC 20004-1111. Telephone: (202) 272–0024 (voice) or (202) 272–0070 (TTY)
-    E-mail addresses: <a href="mailto:508@access-board.gov.">508@access-board.gov</a></p>
+    E-mail addresses: <a href="mailto:508@access-board.gov">508@access-board.gov</a>.</p>
   <p>&nbsp;</p>
   <hr />
   <h2>SUPPLEMENTARY INFORMATION:</h2>
   <h3 id="i-executive-summary">I. Executive Summary</h3>
-  <ol style="list-style-type:upper-alpha">
-    <li><a href="#a-purpose-legal-authority">Purpose and Legal Authority</a></li>
-    <li> <a href="#b-key-provisions">Summary of Key Provisions</a></li>
-    <li> <a href="#c-regulatory-impact-analysis">Summary of Final Regulatory Impact Analysis</a></li>
-  </ol>
   <h4>A. Purpose and Legal Authority</h4>
   <p>In this final rule, the Access Board is updating its existing Electronic and Information Technology Accessibility
     Standards under section 508 of the Rehabilitation Act of 1973, ("508 Standards"), as well as our Telecommunications
@@ -233,7 +227,7 @@ version: original
     lower costs).</p>
   <table class="data">
     <caption>
-      Table 1 - Annualized Value of Monetized Benefits and Costs under the Final Rule, 2018-2027 (in 2017 dollars)
+    Table 1 - Annualized Value of Monetized Benefits and Costs under the Final Rule, 2018-2027 (in 2017 dollars)
     </caption>
     <thead>
       <tr>
@@ -325,14 +319,6 @@ version: original
     Section V.A (Regulatory Process Matters – Final Regulatory Impact Analysis).</p>
   <hr />
   <h3>II. Rulemaking History</h3>
-  <ol style="list-style-type:upper-alpha">
-    <li><a href="#a-existing-standards-guidelines">Existing 508 Standards and 255 Guidelines (1998–2000)</a></li>
-    <li> <a href="#b-advisory-committee">TEITAC Advisory Committee (2006–2008)</a></li>
-    <li> <a href="#c-first-anprm">First Advance Notice of Proposed Rulemaking (2010)</a></li>
-    <li> <a href="#d-second-anprm">Second Advance Notice of Proposed Rulemaking (2011 ANPRM)</a></li>
-    <li> <a href="#e-nprm">Notice of Proposed Rulemaking (2015 NPRM)</a></li>
-    <li> <a href="#f-harmonization-european-activities">Harmonization with European Activities</a></li>
-  </ol>
   <h4>A. Existing 508 Standards and 255 Guidelines (1998–2000)</h4>
   <p>The Access Board issued the existing 255 Guidelines for telecommunications equipment and customer premises
     equipment in 1998. Telecommunications Act Accessibility Guidelines, 63 FR 5608 (Feb. 3, 1998) (codified at 36 CFR
@@ -349,8 +335,7 @@ version: original
     and mandate accessibility of support documentation and services. Generally speaking, the existing 508 Standards take
     a product-based regulatory approach in that technical requirements for electronic and information technology are
     grouped by product type: software applications and operating systems; Web-based intranet and Internet information
-    and applications; telecommunications products; self-contained, closed products; and desktop and portable computers.
-  </p>
+    and applications; telecommunications products; self-contained, closed products; and desktop and portable computers. </p>
   <p>The existing 255 Guidelines require manufacturers of telecommunications equipment and customer premises equipment
     to ensure that new and substantially upgraded existing equipment is accessible to, and usable by, individuals with
     disabilities when readily achievable. 36 CFR part 1193. The existing guidelines, as with the 508 Standards, define
@@ -374,8 +359,7 @@ version: original
     international harmonization.</p>
   <p>In April 2008, the TEITAC Advisory Committee issued its final report to the Access Board (hereafter, "TEITAC
     Report"). See Advisory Committee Report, U.S. Access Board (Apr. 2008), <a
-      href="/guidelines-and-standards/communications-and-it/about-the-ict-refresh/background/teitac-report">http://www.access-board.gov/teitac-report</a>
-    (last accessed Aug. 23, 2016). This TEITAC Report provided a set of recommended updates to the existing 508
+      href="/guidelines-and-standards/communications-and-it/about-the-ict-refresh/background/teitac-report">http://www.access-board.gov/teitac-report</a> (last accessed Aug. 23, 2016). This TEITAC Report provided a set of recommended updates to the existing 508
     Standards and 255 Guidelines, which, the committee noted, were intended to balance two competing considerations: the
     need for clear and specific standards that facilitate compliance, and the recognition that static standards
     "consisting of design specification[s] and fixed checklists" would tend to "stifle innovation" and "delay the
@@ -390,7 +374,6 @@ version: original
     broad range of ICT functions and features, including: closed functionality; hardware with and without speech output;
     user interfaces; electronic content; processing and display of captions and audio description; RTT; authoring tools;
     and, product support documentation and services. </p>
-
   <h4>C. First Advance Notice of Proposed Rulemaking (2010)</h4>
   <h5>1. General</h5>
   <p>Following publication of the TEITAC Report, the Access Board worked to develop a proposed rule that would "refresh"
@@ -398,8 +381,7 @@ version: original
     Rulemaking (2010 ANPRM) inviting public comment on an initial set of draft revisions to the standards and
     guidelines. See Advance Notice of Proposed Rulemaking, 75 FR 13457 (proposed Mar. 22, 2010); see also Draft
     Information and Communication Technology (ICT) Standards and Guidelines, U.S. Access Board, <a
-      href="/guidelines-and-standards/communications-and-it/about-the-ict-refresh/proposed-rule">https://www.access-board.gov/guidelines-and-standards/communications-and-it/about-the-ict-refresh/background/draft-rule-2010</a>
-    (last accessed Aug. 23, 2016).</p>
+      href="/guidelines-and-standards/communications-and-it/about-the-ict-refresh/proposed-rule">https://www.access-board.gov/guidelines-and-standards/communications-and-it/about-the-ict-refresh/background/draft-rule-2010</a> (last accessed Aug. 23, 2016).</p>
   <p>In sum, the 2010 ANPRM proposed a set of accessibility requirements that largely tracked the TEITAC Report's
     recommendations. While the majority of the proposed requirements in the draft rule were not substantively changed
     from the existing 508 Standards and 255 Guidelines, there were some notable proposed substantive revisions. Two of
@@ -416,8 +398,7 @@ version: original
     DC). We also received 384 written comments during the comment period. Comments came from industry, Federal and state
     governments, foreign and domestic companies specializing in information technology, disability advocacy groups,
     manufacturers of hardware and software, trade associations, institutions of higher education, research and trade
-    organizations, accessibility consultants, assistive technology industry and related organizations, and individuals.
-  </p>
+    organizations, accessibility consultants, assistive technology industry and related organizations, and individuals. </p>
   <p>In general, commenters agreed with our approach to addressing the accessibility of ICT through functionality rather
     than discrete product types. Commenters also expressed strong support for our efforts to update the existing 508
     Standards and 255 Guidelines, as well as our decision to follow the TEITAC Advisory Committee's recommendation to
@@ -475,7 +456,7 @@ version: original
     Communication Technology Standards and Guidelines, 80 FR 10879 (proposed Feb. 27, 2015) (hereinafter, NPRM). This
     proposed rule—while making editorial changes and other updates in response to comments on the 2011 ANPRM— retained
     the same overall structure and approach to referencing WCAG 2.0.</p>
-    <h5>2. Hearings and Comments</h5>
+  <h5>2. Hearings and Comments</h5>
   <p>Hearings were held on March 5, 2015 in San Diego, CA, on March 11, 2015 in Washington, DC, and April 29, 2015 in
     Salt Lake City, UT. Additionally, 137 written comments were received in response to the NPRM. Comments came from
     industry, Federal and state governments, disability advocacy groups, manufacturers of hardware and software, trade
@@ -522,8 +503,7 @@ version: original
     EU-US Economic Initiative, the Access Board and the European Commission began to work closely on the issue of
     Information and Communication Technology standards. See, e.g., European Comm., Implementation of the Economic
     Initiative of the June 2005 EU-US Summit: Joint EU-US Work Programme (Nov. 2005), available at <a
-      href="http://trade.ec.europa.eu/doclib/docs/2006/june/tradoc_127643.pdf">http://trade.ec.europa.eu/doclib/docs/2006/june/tradoc_127643.pdf</a>.
-  </p>
+      href="http://trade.ec.europa.eu/doclib/docs/2006/june/tradoc_127643.pdf">http://trade.ec.europa.eu/doclib/docs/2006/june/tradoc_127643.pdf</a>. </p>
   <p>In 2005, the European Commission issued Mandate 376, which sought the assistance of several private European
     standards organizations in the development of European accessibility guidelines for public ICT procurements. See
     European Comm., M 376 – Standardisation Mandate to CEN, CENELEC, and ETSI in Support of European Accessibility
@@ -542,8 +522,7 @@ version: original
       href="#n1">1</a> The functional accessibility requirements specified in EN 301 549 are "closely harmonized" with
     the then-current draft revisions Section 508 Standards (i.e., the 2011 ANPRM). Accessible ICT Procurement Toolkit –
     Frequently Asked Questions, Mandate 376, <a
-      href="http://mandate376.standards.eu/frequently-asked-questions#difference">http://mandate376.standards.eu/frequently-asked-questions#difference</a>
-    (last accessed Aug. 23, 2016). Unlike the 508 Standards, however, EN 301 549—by its own terms— establishes only
+      href="http://mandate376.standards.eu/frequently-asked-questions#difference">http://mandate376.standards.eu/frequently-asked-questions#difference</a> (last accessed Aug. 23, 2016). Unlike the 508 Standards, however, EN 301 549—by its own terms— establishes only
     non-binding, voluntary accessibility requirements for public ICT procurements. Id. <br />
     <br />
     In October 2016, the European Parliament and Council of the European Union issued Directive 2016/2102, which
@@ -569,7 +548,7 @@ version: original
     below:</p>
   <table class="data">
     <caption>
-      Table 2 - Formatting Differences between the Final rule and EN 301 549
+    Table 2 - Formatting Differences between the Final rule and EN 301 549
     </caption>
     <thead>
       <tr>
@@ -577,60 +556,46 @@ version: original
         <th scope="col">EN 301 549 V1.1.2 (2015-04) </th>
         <th scope="col">Final Rule </th>
       </tr>
-      </thead>
-      <tbody>
+    </thead>
+    <tbody>
       <tr>
         <th rowspan="7" scope="rowgroup">Number of chapters<br />
-          Note: EN 301 549 breaks out several sections as separate chapters which are combined in the Board's final rule
-        </th>
+          Note: EN 301 549 breaks out several sections as separate chapters which are combined in the Board's final rule </th>
         <td>13</td>
         <td>6</td>
       </tr>
       <tr>
-        <td>
-          <p>Chapter 2 – References</p>
-          <p>Chapter 3 – Definitions and Abbreviations</p>
-        </td>
+        <td><p>Chapter 2 – References</p>
+          <p>Chapter 3 – Definitions and Abbreviations</p></td>
         <td>Chapter 1 – Application and Administration</td>
       </tr>
       <tr>
-        
-        <td>
-          <p>Chapter 1– Scope</p>
+        <td><p>Chapter 1– Scope</p>
           <p>Chapter 9 – Web (lists each WCAG 2.0 Level AA success criteria)</p>
           <p>Chapter 10 – non-Web Documents (lists each success criteria in WCAG 2.0 Level AA using non-Web phrasing as
             needed. "Empty clause" is used for the four problematic success criteria, to align sub-provision numbering
-            with other chapters.)</p>
-        </td>
-        <td>
-          <p>Chapter 2 – Scoping Requirements</p>
+            with other chapters.)</p></td>
+        <td><p>Chapter 2 – Scoping Requirements</p>
           <p>We use incorporation by reference to include the WCAG 2.0 Level AA success criteria</p>
           <p>For non-Web documents, we are explicit with the word substitution necessary, and provide an exception for
-            the four problematic success criteria</p>
-        </td>
+            the four problematic success criteria</p></td>
       </tr>
       <tr>
-       
         <td>Chapter 4 – Functional Performance</td>
         <td>Chapter 3 – Functional Performance Criteria</td>
       </tr>
       <tr>
-        
-        <td>
-          <p>Chapter 5 – Generic requirements (e.g., closed functionality, biometrics, operable parts)</p>
+        <td><p>Chapter 5 – Generic requirements (e.g., closed functionality, biometrics, operable parts)</p>
           <p>Chapter 6 – ICT with two-way voice communications</p>
           <p>Chapter 7 – ICT with video capabilities</p>
-          <p>Chapter 8 – Hardware</p>
-        </td>
+          <p>Chapter 8 – Hardware</p></td>
         <td>Chapter 4 – Hardware</td>
       </tr>
       <tr>
-       
         <td>Chapter 11 – Software</td>
         <td>Chapter 5 – Software</td>
       </tr>
       <tr>
-      
         <td>Chapter 12 – Documentation and support services</td>
         <td>Chapter 6 – Support Documentation and Services</td>
       </tr>
@@ -640,33 +605,25 @@ version: original
         <td>No comparable chapter</td>
       </tr>
       <tr>
-        
         <td>Annex A (informative) – WCAG 2.0</td>
         <td>No comparable chapter. We are using incorporation by reference, and not reprinting the entire standard.</td>
       </tr>
       <tr>
-        
         <td>Annex B (informative) – Relationships between requirements and functional performance statements.</td>
         <td>No comparable chapter. Similar comparisons are found in the TEITAC Report.</td>
       </tr>
       <tr>
-       
         <td>Annex C (normative) – Determination of compliance</td>
         <td>Not within the scope of Section 508 or Section 255, Section 508 compliance is determined by each Federal
           agency</td>
       </tr>
       <tr>
-        
-        <td>
-          <p>Section 8.3.2 Clear floor or ground space</p>
+        <td><p>Section 8.3.2 Clear floor or ground space</p>
           <p>Section 8.3.2.1 Change in level</p>
-          <p>Section 8.3.2.2 Clear floor or ground space</p>
-        </td>
-        <td>
-          <p>Not within the scope of Section 508 or Section 255</p>
+          <p>Section 8.3.2.2 Clear floor or ground space</p></td>
+        <td><p>Not within the scope of Section 508 or Section 255</p>
           <p>Most similar to "303 Changes in Level" and "305 Clear Floor or Ground Space" from the 2010 ADA Standards
-            for Accessible Design</p>
-        </td>
+            for Accessible Design</p></td>
       </tr>
       <tr>
         <th rowspan="2" scope="rowgroup">Differing treatment of similar concepts</th>
@@ -674,24 +631,14 @@ version: original
         <td>412.5 Real-Time Text Functionality is reserved.</td>
       </tr>
       <tr>
-        
         <td>6.5 Video communication</td>
-        <td>
-          <p>412.7 Video Communication</p>
-          <p>Their 6.5 is a prescriptive standard while our 412.7 is a performance standard</p>
-        </td>
+        <td><p>412.7 Video Communication</p>
+          <p>Their 6.5 is a prescriptive standard while our 412.7 is a performance standard</p></td>
       </tr>
     </tbody>
   </table>
   <hr />
   <h3>III. Major Issues</h3>
-  <ol style="list-style-type:upper-alpha">
-    <li><a href="#a-electronic-content">508 Standards: Covered Electronic Content</a></li>
-    <li> <a href="#b-WCAG2.0-non-web-ict">Application of WCAG 2.0 to Non-Web ICT</a> </li>
-    <li> <a href="#c-pdf-ua-1">C. Incorporation by Reference of PDF/UA-1</a></li>
-    <li> <a href="#d-real-time-text">D. Real-Time Text</a> </li>
-    <li> <a href="#e-functional-performance-criteria">E. Functional Performance Criteria</a></li>
-  </ol>
   <h4>A. 508 Standards: Covered Electronic Content</h4>
   <p>The NPRM delineated specific types of electronic content that Federal agencies would need to make accessible
     consistent with the technical requirements of the proposed rule. As explained in the NPRM, the Board proposed these
@@ -950,8 +897,7 @@ version: original
     a lack of accessibility, and without a baseline, could result in unnecessary magnification of content that is
     already sufficiently large, or reduction of a field of vision that is already sufficiently small for limited vision
     users. The group suggested that the Board alter the provision to require one mode readable by a user with 20/40
-    vision acuity, one mode that is usable with a 10-degree field of vision, and one mode that provides high contrast.
-  </p>
+    vision acuity, one mode that is usable with a 10-degree field of vision, and one mode that provides high contrast. </p>
   <p>The ICT companies and trade associations asserted that the proposed FPC for limited vision was too prescriptive,
     and was inconsistent with the level of specificity contained in the proposed FPCs for other disabilities. These
     commenters further noted that the FPC for limited vision imposed criteria not required by the technical
@@ -1029,8 +975,7 @@ version: original
     language, or learning disabilities, the Board finds that it would be inappropriate to exclude the needs of this
     population from the Revised 508 Standards and 255 Guidelines. U.S. Census, Sex By Age By Cognitive Difficulty,
     2010-2014 American Community Survey 5-Year Estimates, <a
-      href="http://factfinder.census.gov/faces/tableservices/jsf/pages/productview.xhtml?pid=ACS_14_5YR_B18104&amp;prodType=table">http://factfinder.census.gov/faces/tableservices/jsf/pages/productview.xhtml?pid=ACS_14_5YR_B18104&amp;prodType=table</a>
-    (last visited on Aug. 8, 2016) (estimating that in 2014 almost 5 percent of the civilian non-institutionalized U.S.
+      href="http://factfinder.census.gov/faces/tableservices/jsf/pages/productview.xhtml?pid=ACS_14_5YR_B18104&amp;prodType=table">http://factfinder.census.gov/faces/tableservices/jsf/pages/productview.xhtml?pid=ACS_14_5YR_B18104&amp;prodType=table</a> (last visited on Aug. 8, 2016) (estimating that in 2014 almost 5 percent of the civilian non-institutionalized U.S.
     population 5 years old and older had a cognitive disability). The existing 255 Guidelines contain an FPC for limited
     cognition. While evaluation of accessibility under this existing provision has posed some challenges, the Board
     nonetheless concludes that, given the significant population of Americans with limited cognitive, language, or
@@ -1051,18 +996,6 @@ version: original
     basis following the organization of the final rule. Also addressed below are requirements in the final rule that
     have been substantively revised from the proposed rule. Provisions in the final rule that neither received
     significant comment nor materially changed from the proposed rule are not discussed in this preamble.</p>
-  <ol style="list-style-type:upper-alpha">
-    <li> <a href="#a-508-1-application">508 Chapter 1: Application and Administration</a> </li>
-    <li> <a href="#b-508-2-scoping">508 Chapter 2: Scoping Requirements</a> </li>
-    <li> <a href="#c-255-1-application">255 Chapter 1: Application and Administration</a></li>
-    <li> <a href="#d-255-2-scoping">255 Chapter 2: Scoping Requirements</a></li>
-    <li> <a href="#e-3-functional-performance-criteria">Chapter 3: Functional Performance Criteria</a></li>
-    <li> <a href="#f-4-hardware">Chapter 4: Hardware</a></li>
-    <li> <a href="#g-5-software">Chapter 5: Software</a></li>
-    <li> <a href="#h-6-documentation-services">Chapter 6: Support Documentation and Services</a></li>
-    <li> <a href="#i-7-referenced-standards">Chapter 7: Referenced Standards</a></li>
-    <li> <a href="#j-508-compliance-effective-dates">Revised 508 Standards: Compliance and Effective Dates</a> </li>
-  </ol>
   <h4>A. 508 Chapter 1: Application and Administration </h4>
   <p>Chapter 1 of the Revised 508 Standards contains a general section that defines equivalent facilitation, addresses
     application of referenced standards, and provides definitions of terms used in the Standards. In the final rule, the
@@ -1071,8 +1004,7 @@ version: original
     the Office of the Federal Register (OFR) that govern incorporations by reference in the Federal Register. This
     reorganization of IBR provisions is discussed at greater length in Section IV.I (Summary of Comments and Responses
     on Other Aspects of the Proposed Rule – Chapter 7: Referenced Standards). We have also made minor changes to 508
-    Chapter 1 in response to comments to improve clarity, accuracy, and ease of use. These changes are described below.
-  </p>
+    Chapter 1 in response to comments to improve clarity, accuracy, and ease of use. These changes are described below. </p>
   <h5>E101.3 Conventional Industry Tolerances</h5>
   <p>The NPRM proposed this section in the interests of being explicit about dimensions. We did not receive any comments
     on this provision but have decided, for the purpose of clarity and consistency with the Board's other rulemakings,
@@ -1356,8 +1288,7 @@ version: original
     non-conforming version can only be reached from the conforming version; or (3) the non-conforming version can only
     be reached from a conforming page that also provides a mechanism to reach the conforming version. W3C®,
     Understanding WCAG 2.0: Understanding Conforming Alternate Versions, Dec. 2012, <a
-      href="http://www.w3.org/TR/UNDERSTANDING-WCAG20/conformance.html#uc-conforming-alt-versions-head">http://www.w3.org/TR/UNDERSTANDING-WCAG20/conformance.html#uc-conforming-alt-versions-head</a>.
-  </p>
+      href="http://www.w3.org/TR/UNDERSTANDING-WCAG20/conformance.html#uc-conforming-alt-versions-head">http://www.w3.org/TR/UNDERSTANDING-WCAG20/conformance.html#uc-conforming-alt-versions-head</a>. </p>
   <p>The W3C® explains that providing a conforming alternate version is intended to be a "fallback option for
     conformance to WCAG and the preferred method of conformance is to make all content directly accessible." Id. While
     some commenters expressed specific concern that the use of conforming alternate versions could still create
@@ -1423,15 +1354,13 @@ version: original
     exception as an editorial clarification since we never intended for assistive technology to be reviewed against the
     WCAG 2.0 Success Criteria. Moving the exception from Chapter 5 to Chapter 2 makes this clear, but requires that the
     exception be repeated in multiple places.</p>
-  
   <h4>C. 255 Chapter 1: Application and Administration </h4>
   <p>Chapter 1 of the Revised 255 Guidelines includes a general section, defines equivalent facilitation, addresses
     application of referenced standards, and provides definitions of terms used in the guidelines. Most of the comments
     received on 508 Chapter 1, discussed above in Section IV.A. (Summary of Comments and Responses on Other Aspects of
     the Proposed Rule — 508 Chapter 1: Application and Administration), are also applicable to 255 Chapter 1. These are
     noted below with the applicable section numbers. Additionally, we have made minor changes specific to the 255
-    Chapter 1 in response to comments to improve clarity, accuracy, and ease of use. These changes are described below.
-  </p>
+    Chapter 1 in response to comments to improve clarity, accuracy, and ease of use. These changes are described below. </p>
   <h5>C101.1 Purpose</h5>
   <p>An ICT trade association raised a concern that inclusion of the phrase "and related software," could be interpreted
     to go beyond the scope of Section 255 to cover software other than that essential to telecommunications functions.
@@ -1502,8 +1431,7 @@ version: original
     suggesting that the Board add three new functional performance criteria (FPC) to the final rule addressing depth
     perception, the use of ICT without gestures, and the use of ICT without human skin contact. The purpose of these
     recommendations was to anticipate possible developments in technology that would require the use of functions not
-    currently addressed in the Revised 508 Standards and 255 Guidelines. Each of these suggestions are discussed below.
-  </p>
+    currently addressed in the Revised 508 Standards and 255 Guidelines. Each of these suggestions are discussed below. </p>
   <p>The requested addition for a FPC addressing depth perception would require that one visual mode of operation be
     provided that does not require binocular perception of depth. This commenter did not indicate what functions of ICT
     would require binocular perception of depth, or where this criterion might apply, other than to suggest that at some
@@ -1520,8 +1448,7 @@ version: original
     on a display the user touches. Because of this, capacitive displays can be controlled with very light touches of a
     finger and generally cannot be used with a mechanical stylus or a gloved hand. See "What is 'capacitive
     touchscreen'?", <a
-      href="http://www.mobileburn.com/definition.jsp?term=capacitive+touchscreen">http://www.mobileburn.com/definition.jsp?term=capacitive+touchscreen</a>
-    (last visited Aug. 3, 2016). While resistive, or pressure sensitive touch screens, are available for such functions
+      href="http://www.mobileburn.com/definition.jsp?term=capacitive+touchscreen">http://www.mobileburn.com/definition.jsp?term=capacitive+touchscreen</a> (last visited Aug. 3, 2016). While resistive, or pressure sensitive touch screens, are available for such functions
     as signing an ATM screen, they can only recognize one activation point at a time. This technical limitation
     precludes the use of resistive touch screens for common gestures used with personal devices (for example,
     pinch-to-zoom on a smart phone). See "Okay, but how do touch screens actually work?" at Science Line, the Shortest
@@ -1628,7 +1555,7 @@ version: original
     the coalition of disability rights groups recommended that we clarify the text of the provision to make it easier to
     understand. In response to this comment, we have added the phrase "simultaneous manual operations" to clarify the
     limitation on this FPC. </p>
-    <h4>F. Chapter 4: Hardware </h4>
+  <h4>F. Chapter 4: Hardware </h4>
   <p>Chapter 4 contains requirements for hardware that transmits information or has a user interface. Examples of such
     hardware include computers, information kiosks, and multi-function copy machines. Chapter 4 in the final rule has
     been substantially reorganized from the proposed rule in response to comments to improve clarity, accuracy and ease
@@ -1823,8 +1750,7 @@ version: original
     interfere with an individual's ability to perceive instructions given solely in the form of audible output.
     Likewise, an exception that permitted a device to rely solely on gesture controls might not be accessible to
     individuals who are blind or who are unable to gesture. We have retained the exception proposed in the NPRM, which
-    is limited to personal use devices that are discernable audibly without activation (proposed 407.3; final 407.3).
-  </p>
+    is limited to personal use devices that are discernable audibly without activation (proposed 407.3; final 407.3). </p>
   <p>The NPRM proposed that input controls be tactilely discernible and operable by touch and, where provided, that key
     surfaces outside active areas of the display screen shall be raised above the surrounding surface. A number of
     commenters (an ICT company, two ICT trade associations, and a disability advocacy organization), opposed the
@@ -1919,8 +1845,7 @@ version: original
     volume gain for analog and digital wireline telephones. As noted by several commenters from ICT trade associations,
     it does not address volume gain for wireless devices (e.g., mobile phones). We have amended the provisions on volume
     gain to distinguish between volume gain requirements for wireline telephones and non-wireline devices. The Board
-    will consider further updates to these requirements at such time as the FCC completes its rulemaking on this issue.
-  </p>
+    will consider further updates to these requirements at such time as the FCC completes its rulemaking on this issue. </p>
   <p>The proposed rule contained two separate provisions addressing magnetic coupling and minimizing interference
     (proposed 410.3 and 410.4). We received two comments, one from an ICT trade association and one from a coalition of
     disability rights organizations, urging that the two provisions be combined since they address related features of
@@ -1996,8 +1921,7 @@ version: original
     Web applications that conform to WCAG, but is not required for WCAG conformance. WAI-ARIA is a valuable
     specification, but the technology it addresses is too narrow for our Standards and Guidelines to require its use at
     this time.</p>
-  <p>Authoring Tool Accessibility Guidelines (ATAG) 2.0 is a completed W3C® Recommendation. (ATAG 2.0, Sept. 24, 2015,
-    <a href="http://w3.org/TR/ATAG20">http://w3.org/TR/ATAG20</a>). The Board relied on ATAG 2.0 in developing the
+  <p>Authoring Tool Accessibility Guidelines (ATAG) 2.0 is a completed W3C® Recommendation. (ATAG 2.0, Sept. 24, 2015, <a href="http://w3.org/TR/ATAG20">http://w3.org/TR/ATAG20</a>). The Board relied on ATAG 2.0 in developing the
     requirements for authoring tools included in Revised 508 Standards and 255 Guidelines (proposed 504; final 504).
     Since ATAG 2.0 applies to software, many of its requirements are redundant to our requirements in 502 and 503. ATAG
     2.0 is very narrowly focused on Web content and is very prescriptive. For these reasons, and because of the limited
@@ -2273,14 +2197,12 @@ version: original
     ICT industry representatives and some consumer groups), it does not appear that the process was sufficiently open or
     balanced to satisfy the requirements of Circular A-119. See, e.g., ACT NOW! EDF Position on the European Standard on
     Accessibility Requirements for Public Procurement of ICT, EASPD, <a
-      href="http://www.easpd.eu/en/content/act-now-edf-position-european-standard-accessibility-requirements-suitable-public">http://www.easpd.eu/en/content/act-now-edf-position-european-standard-accessibility-requirements-suitable-public</a>
-    (last accessed Aug. 23, 2016) (noting concern that interests of persons with disabilities were not sufficiently
+      href="http://www.easpd.eu/en/content/act-now-edf-position-european-standard-accessibility-requirements-suitable-public">http://www.easpd.eu/en/content/act-now-edf-position-european-standard-accessibility-requirements-suitable-public</a> (last accessed Aug. 23, 2016) (noting concern that interests of persons with disabilities were not sufficiently
     represented during the development of EN 301 549 due to non-voting status of disability rights organizations); VVA
     Europe Ltd., European Association for the Coordination of Consumers Representation in Standardisation (ANEC),
     Preliminary Study on Benefits of Consumer Participation in Standardisation to All Stakeholders 45-52 (Nov. 13,
     2014), available at <a
-      href="http://www.anec.eu/attachments/ANEC-R&amp;T-2014-SC-006.pdf">http://www.anec.eu/attachments/ANEC-R&amp;T-2014-SC-006.pdf</a>
-    (noting similar concerns with respect to consumer groups) Thus, while EN 301 549 represents an important step
+      href="http://www.anec.eu/attachments/ANEC-R&amp;T-2014-SC-006.pdf">http://www.anec.eu/attachments/ANEC-R&amp;T-2014-SC-006.pdf</a> (noting similar concerns with respect to consumer groups) Thus, while EN 301 549 represents an important step
     towards a more accessible ICT environment and serves as a meaningful set of technical specifications for public
     procurements of ICT in the European Union, it is not a voluntary consensus standard within the meaning of Circular
     A-119.</p>
@@ -2323,8 +2245,7 @@ version: original
     on the need to revise EN 301 549 as soon as possible, with the aim to improve the document and to harmonize it with
     the next version of Section 508 as soon as [it] is public." European Joint Working Group on eAccessibility, Draft
     Minutes 9th eAcc Meeting 7 (Dec. 10, 2015), <a
-      href="http://www.itu.int/en/ITU-T/jca/ahf/Documents/Doc%20219.pdf">http://www.itu.int/en/ITU-T/jca/ahf/Documents/Doc%20219.pdf</a>.
-  </p>
+      href="http://www.itu.int/en/ITU-T/jca/ahf/Documents/Doc%20219.pdf">http://www.itu.int/en/ITU-T/jca/ahf/Documents/Doc%20219.pdf</a>. </p>
   <p>For the foregoing reasons, the Access Board declines to reference EN 301 549 in the Revised 508 Standards or
     otherwise state that conformance with EN 301 549 equates to compliance with the final rule. The Revised 508
     Standards' requirements closely track the EN 301 549 phrasing where appropriate. In places where the Revised 508
@@ -2367,7 +2288,7 @@ version: original
     available by purchase (i.e., publisher or online standards store) or personal inspection without charge at the
     offices of either the Access Board or the National Archives and Records Administration. See id.; see also 702.9
     (providing information on obtaining standard from publisher).</p>
-    <h4>J. Revised 508 Standards: Compliance and Effective Dates</h4>
+  <h4>J. Revised 508 Standards: Compliance and Effective Dates</h4>
   <p>In the NPRM, the Board noted that it was considering making the Revised 508 Standards effective six months after
     publication in the Federal Register. The Board also noted it was considering deferring to the Federal Acquisition
     Regulatory Council (FAR Council) to establish the effective date for application of the Revised 508 Standards to new
@@ -2404,16 +2325,6 @@ version: original
     regulations to new and existing procurements.</p>
   <hr />
   <h3>V. Regulatory Process Matters</h3>
-  <ol style="list-style-type:upper-alpha">
-    <li><a href="#a-regulatory-impact-analysis">Final Regulatory Impact Analysis</a> </li>
-    <li> <a href="#b-regulatory-flexibility-act">Regulatory Flexibility Act</a></li>
-    <li> <a href="#c-federalism">Executive Order 13132: Federalism</a></li>
-    <li> <a href="#d-promoting-international-regulatory-cooperation">Executive Order 13609: Promoting International
-        Regulatory Cooperation</a></li>
-    <li> <a href="#e-unfunded-mandates-reform-act">Unfunded Mandates Reform Act</a></li>
-    <li> <a href="#f-paperwork-reduction-act">Paperwork Reduction Act</a></li>
-    <li> <a href="#g-materials-incorporated-by-reference">Availability of Materials Incorporated by Reference</a></li>
-  </ol>
   <h4>A. Final Regulatory Impact Analysis</h4>
   <p>Executive Orders 13563 and 12866 direct agencies to propose or adopt a regulation only upon a reasoned
     determination that its benefits justify its costs; tailor the regulation to impose the least burden on society,
@@ -2494,8 +2405,7 @@ version: original
     over three years, rather than the 2-year period used in the Preliminary RIA. (A similar 3-year implementation period
     is assumed for Section 255-related costs and benefits in recognition that software development and similar
     technology tasks typically take place over an extended period of time.) </p>
-    <p>
-    Table 3 below summarizes the results from the Final RIA in terms of likely monetized benefits and costs, on an
+  <p> Table 3 below summarizes the results from the Final RIA in terms of likely monetized benefits and costs, on an
     annualized basis, from the Revised 508 Standards and 255 Guidelines. All benefit and cost values are incremental to
     the applicable baseline, and were estimated for a 10-year time horizon starting in 2018 (since the final rule
     requires Federal agencies to comply one year after its publication) and converted to annualized values using
@@ -2504,11 +2414,10 @@ version: original
     a low net benefit scenario using parameters that result in lower benefits and higher costs; an expected scenario
     consisting of expected values for assumed parameters; and a high net benefit scenario using parameters that result
     in higher benefits and lower costs.</p>
-  
   <table class="data" id="table3">
     <caption>
-      Table 3 - Annualized Value of Monetized Benefits and Costs under the Revised 508 Standards and 255 Guidelines,
-      2018-2027 (in Millions of 2017 Dollars)
+    Table 3 - Annualized Value of Monetized Benefits and Costs under the Revised 508 Standards and 255 Guidelines,
+    2018-2027 (in Millions of 2017 Dollars)
     </caption>
     <thead>
       <tr>
@@ -2544,8 +2453,7 @@ version: original
         <th colspan="7" scope="colgroup" id="mib">Monetized Incremental Benefits</th>
       </tr>
       <tr>
-        <th id="bf">Benefits to Federal agencies from increased productivity by Federal employees with addressable disabilities
-        </th>
+        <th id="bf">Benefits to Federal agencies from increased productivity by Federal employees with addressable disabilities </th>
         <td headers="mib bf lnbs lnbs7">$18.2</td>
         <td headers="mib bf lnbs lnbs3">$19.3</td>
         <td headers="mib bf es es7">$47.7</td>
@@ -2633,7 +2541,6 @@ version: original
       </tr>
     </tbody>
   </table>
-
   <p>It is important to note that some potentially material benefits and costs from the Revised 508 Standards and 255
     Guidelines are neither reflected in the table above nor monetized in the Final RIA due to lack of data or for other
     methodological constraints. These unquantified benefits and costs are described qualitatively below.</p>
@@ -2655,55 +2562,52 @@ version: original
     these unquantified (or inherently unquantifiable) benefits of the Revised 508 Standards are listed in Table 4 below.
     The fact that these benefits were not be formally assessed in this Final RIA should not diminish their importance or
     value.</p>
-   
-   <p class="text-bold">Table 4 - Unquantified Benefits of the Final Rule</p>
-    
+  <p class="text-bold">Table 4 - Unquantified Benefits of the Final Rule</p>
   <table role="presentation" class="data">
-      <tr>
-        <td>Increased employment of individuals with disabilities</td>
-      </tr>
-      <tr>
-        <td>Increased ability of individuals with disabilities to obtain information on Federal agency Web sites and
-          conduct transactions electronically</td>
-      </tr>
-      <tr>
-        <td>Greater independence for individuals with disabilities to access information and services on Federal agency
-          Web sites without assistance</td>
-      </tr>
-      <tr>
-        <td>More civic engagement by individuals with disabilities due to improved access to information and services on
-          Federal agency Web sites</td>
-      </tr>
-      <tr>
-        <td>Increased ability of individuals with disabilities to evaluate, purchase, and make full use of
-          telecommunications products due to increased accessibility of support documentation and services</td>
-      </tr>
-      <tr>
-        <td>Increased ability of individuals without disabilities to access information and conduct their business
-          electronically when they face situational limitations (in a noisy place, in a low-bandwidth environment, or in
-          bright sunlight)</td>
-      </tr>
-      <tr>
-        <td>Potential cost savings to Federal agencies due to reduced levels of in-person visits and mail correspondence
-        </td>
-      </tr>
-      <tr>
-        <td>Larger pool of ICT developers and content creators with accessibility knowledge and skills, providing more
-          choice to Federal agencies due to use of internationally recognized, industry-driven standards)</td>
-      </tr>
-      <tr>
-        <td>Potential cost savings to manufacturers of telecommunications and CPE, state and local governments, and
-          non-profit entities, as internationally harmonized standards reduce costs for ICT manufacturers and allow them
-          to sell a single line of accessible products and services across all types of markets</td>
-      </tr>
-      <tr>
-        <td>Intrinsic existence value that individuals both with and without disabilities derive from the
-          non-discrimination and equity values served by Sections 508 and 255</td>
-      </tr>
-      <tr>
-        <td>Cost savings to agencies already complying with equivalent WCAG 2.0 standards because of the availability of
-          WCAG 2.0 support materials</td>
-      </tr>
+    <tr>
+      <td>Increased employment of individuals with disabilities</td>
+    </tr>
+    <tr>
+      <td>Increased ability of individuals with disabilities to obtain information on Federal agency Web sites and
+        conduct transactions electronically</td>
+    </tr>
+    <tr>
+      <td>Greater independence for individuals with disabilities to access information and services on Federal agency
+        Web sites without assistance</td>
+    </tr>
+    <tr>
+      <td>More civic engagement by individuals with disabilities due to improved access to information and services on
+        Federal agency Web sites</td>
+    </tr>
+    <tr>
+      <td>Increased ability of individuals with disabilities to evaluate, purchase, and make full use of
+        telecommunications products due to increased accessibility of support documentation and services</td>
+    </tr>
+    <tr>
+      <td>Increased ability of individuals without disabilities to access information and conduct their business
+        electronically when they face situational limitations (in a noisy place, in a low-bandwidth environment, or in
+        bright sunlight)</td>
+    </tr>
+    <tr>
+      <td>Potential cost savings to Federal agencies due to reduced levels of in-person visits and mail correspondence </td>
+    </tr>
+    <tr>
+      <td>Larger pool of ICT developers and content creators with accessibility knowledge and skills, providing more
+        choice to Federal agencies due to use of internationally recognized, industry-driven standards)</td>
+    </tr>
+    <tr>
+      <td>Potential cost savings to manufacturers of telecommunications and CPE, state and local governments, and
+        non-profit entities, as internationally harmonized standards reduce costs for ICT manufacturers and allow them
+        to sell a single line of accessible products and services across all types of markets</td>
+    </tr>
+    <tr>
+      <td>Intrinsic existence value that individuals both with and without disabilities derive from the
+        non-discrimination and equity values served by Sections 508 and 255</td>
+    </tr>
+    <tr>
+      <td>Cost savings to agencies already complying with equivalent WCAG 2.0 standards because of the availability of
+        WCAG 2.0 support materials</td>
+    </tr>
   </table>
   <h5>3. Costs of the Final Rule</h5>
   <p>The Final RIA shows that the Revised 508 Standards and 255 Guidelines will likely increase compliance costs
@@ -2720,39 +2624,38 @@ version: original
     as well as the 2015 NPRM.)</p>
   <p>Some of these unquantified costs of the Revised 508 Standards and 255 Guidelines are listed in Table 5 below.</p>
   <p class="text-bold">Table 5 - Unquantified Costs of the Final Rule</p>
-  
   <table role="presentation" class="data">
-      <tr>
-        <td>Possible increase in Federal Government expenditures to provide accommodations if the government hires more
-          people with addressable disabilities</td>
-      </tr>
-      <tr>
-        <td>Possible decrease in the amount or variety of electronic content produced, as government seeks to reduce
-          Section 508 compliance costs</td>
-      </tr>
-      <tr>
-        <td>Potential costs to state and local governments and non-profit organizations that may be required to make
-          electronic content accessible in order to do businesses with Federal agencies</td>
-      </tr>
-      <tr>
-        <td>Potential costs to ICT manufacturers of developing and producing hardware and telecommunications products
-          that comply with the revised accessibility requirements</td>
-      </tr>
-      <tr>
-        <td>Possible increase in social costs to people with certain vision disabilities because they would have to use
-          commercial screen magnification tools rather than turning off the style sheets (free of charge) in order to
-          read Web pages.</td>
-      </tr>
-      <tr>
-        <td>Costs of increased compliance by foreign telecommunications manufacturers shifted to U.S. end users
-          (consumers)</td>
-      </tr>
+    <tr>
+      <td>Possible increase in Federal Government expenditures to provide accommodations if the government hires more
+        people with addressable disabilities</td>
+    </tr>
+    <tr>
+      <td>Possible decrease in the amount or variety of electronic content produced, as government seeks to reduce
+        Section 508 compliance costs</td>
+    </tr>
+    <tr>
+      <td>Potential costs to state and local governments and non-profit organizations that may be required to make
+        electronic content accessible in order to do businesses with Federal agencies</td>
+    </tr>
+    <tr>
+      <td>Potential costs to ICT manufacturers of developing and producing hardware and telecommunications products
+        that comply with the revised accessibility requirements</td>
+    </tr>
+    <tr>
+      <td>Possible increase in social costs to people with certain vision disabilities because they would have to use
+        commercial screen magnification tools rather than turning off the style sheets (free of charge) in order to
+        read Web pages.</td>
+    </tr>
+    <tr>
+      <td>Costs of increased compliance by foreign telecommunications manufacturers shifted to U.S. end users
+        (consumers)</td>
+    </tr>
   </table>
   <p>In addition, incremental cost estimates in the Final RIA do not reflect other potentially influential factors that
     may occur over time – such as future changes in the fiscal environment and its effect on ICT budgets, the impact of
     recent government-wide initiatives to manage ICT more strategically, efforts to harmonize standards for a global ICT
     market, and trends in technological innovation. </p>
-    <h5>4. Conclusion</h5>
+  <h5>4. Conclusion</h5>
   <p>While the Final RIA estimates that incremental costs, as assessed and monetized in the assessment, exceed the
     monetized benefits of the final rule, this finding represents only a piece of the regulatory story. Today, though
     ICT is now woven into the very fabric of everyday life, millions of Americans with disabilities often find
@@ -2817,11 +2720,10 @@ version: original
     guidelines, if adopted by the FCC, will only be applicable to new products to the extent that compliance is readily
     achievable; they do not require retrofitting of existing equipment or retooling. Manufacturers may consider costs
     and available resources when determining whether, and the extent to which, compliance is required.</p>
-  <p><em>Significant issues raised by public comments in response to the initial regulatory flexibility analysis.</em>
-    The Access Board received no public comment in response to the initial regulatory flexibility analysis provided in
+  <p><em>Significant issues raised by public comments in response to the initial regulatory flexibility analysis.</em> The Access Board received no public comment in response to the initial regulatory flexibility analysis provided in
     the NPRM.</p>
   <p><em>Agency response to comments filed by the Chief Counsel for Advocacy of the Small Business Administration in
-      response to the proposed rule.</em> The Access Board received no comments filed by the Chief Counsel in response
+    response to the proposed rule.</em> The Access Board received no comments filed by the Chief Counsel in response
     to the proposed rule.</p>
   <p><em>Description and estimate of the number of small entities to which the final rule will apply</em>. The Revised
     255 Guidelines cover manufacturers of telecommunications equipment and CPE, as well as the manufacturers of
@@ -2843,7 +2745,7 @@ version: original
     by the Revised 255 Guidelines.</p>
   <table class="data">
     <caption>
-      Table 6 - Small Businesses Potentially Affected by the Revised 255 Guidelines
+    Table 6 - Small Businesses Potentially Affected by the Revised 255 Guidelines
     </caption>
     <thead>
       <tr>
@@ -2920,7 +2822,7 @@ version: original
     small businesses that may be affected by the Revised 255 Guidelines is assumed to be small firms that meet the
     applicable SBA size standard and employ twenty or more workers.</p>
   <p><em>Description of the projected reporting, record keeping, and other compliance requirements for small
-      entities.</em> As discussed above, the Revised 255 Guidelines contain many requirements that are similar to the
+    entities.</em> As discussed above, the Revised 255 Guidelines contain many requirements that are similar to the
     existing guidelines. There is, however, one new accessibility requirement (final 602.3) in the revised guidelines.
     Section 602.3 requires manufacturers of telecommunications equipment and CPE to make their electronic support
     documentation (such as Web-based self-service support and electronic manuals) accessible for users with disabilities
@@ -2948,8 +2850,8 @@ version: original
     reflected below:</p>
   <table class="data">
     <caption>
-      Table 7 - Estimated Incremental Costs for Small Firms Subject to the Revised 255 Guidelines (Scenario 1 – All
-      Small Firms)
+    Table 7 - Estimated Incremental Costs for Small Firms Subject to the Revised 255 Guidelines (Scenario 1 – All
+    Small Firms)
     </caption>
     <thead>
       <tr>
@@ -2998,8 +2900,8 @@ version: original
     estimate, are reflected below: </p>
   <table class="data">
     <caption>
-      Table 8 - Estimated Incremental Costs for Small Firms Subject to the Revised 255 Guidelines (Scenario 2 – Small
-      Firms with 20 or More Employees)
+    Table 8 - Estimated Incremental Costs for Small Firms Subject to the Revised 255 Guidelines (Scenario 2 – Small
+    Firms with 20 or More Employees)
     </caption>
     <thead>
       <tr>
@@ -3055,8 +2957,8 @@ version: original
     covered by Section 255.</p>
   <table class="data">
     <caption>
-      Table 9 - Annualized Per-Firm Costs as a Percentage of Per-Firm Receipts for Small Firms with 100 or More
-      Employees (by NAICS Code)
+    Table 9 - Annualized Per-Firm Costs as a Percentage of Per-Firm Receipts for Small Firms with 100 or More
+    Employees (by NAICS Code)
     </caption>
     <thead>
       <tr>
@@ -3091,16 +2993,14 @@ version: original
       </tr>
     </tbody>
   </table>
-  
-      <p id="t09note">&dagger; <em>Note:</em>&nbsp; Average per-firm annual receipts based on data from
-        the Census Bureau's 2012 annual SUSB dataset. See U.S. Census Bureau, 2012 SUSB Annual Datasets by
-        Establishment Industry, U.S. 6-digit NAICS, detailed employment sizes (release date June 22, 2015).<a
+  <p id="t09note">&dagger; <em>Note:</em>&nbsp; Average per-firm annual receipts based on data from
+    the Census Bureau's 2012 annual SUSB dataset. See U.S. Census Bureau, 2012 SUSB Annual Datasets by
+    Establishment Industry, U.S. 6-digit NAICS, detailed employment sizes (release date June 22, 2015).<a
           href="#n9">9</a></p>
-    
   <table class="data">
     <caption>
-      Table 10 - Annualized Per-Firm Costs as a Percentage of Per-Firm Receipts for Small Firms with 20 and 99 Employees
-      (by NAICS Code)
+    Table 10 - Annualized Per-Firm Costs as a Percentage of Per-Firm Receipts for Small Firms with 20 and 99 Employees
+    (by NAICS Code)
     </caption>
     <thead>
       <tr>
@@ -3138,9 +3038,8 @@ version: original
     </tbody>
   </table>
   <p id="t10note">&Dagger; <em>Note:</em>&nbsp; Average per-firm annual receipts based on data from
-        the Census Bureau's 2012 annual SUSB dataset. See U.S. Census Bureau, 2012 SUSB Annual Datasets by
-        Establishment Industry, U.S. 6-digit NAICS, detailed employment sizes (release date June 22, 2015). </p>
-
+    the Census Bureau's 2012 annual SUSB dataset. See U.S. Census Bureau, 2012 SUSB Annual Datasets by
+    Establishment Industry, U.S. 6-digit NAICS, detailed employment sizes (release date June 22, 2015). </p>
   <p>The results of these annualized cost/receipt analyses demonstrate that incremental costs of the Revised 255
     Guidelines for small businesses—whether larger or smaller than 100 employees—are expected to be minimal relative to
     firm receipts. In no case would this ratio exceed one-tenth of one percent, with values ranging from a low of 0.03%
@@ -3148,8 +3047,7 @@ version: original
     Guidelines are likely to have a significant economic impact on a substantial number of small entities.</p>
   <p>Description of significant alternatives to the Revised 255 Guidelines. In the Board's view, there are no
     alternatives to the final guidelines that would accomplish the goal of meeting the access needs of individuals with
-    disabilities, while taking into account compliance costs of manufacturers of telecommunications equipment and CPE.
-  </p>
+    disabilities, while taking into account compliance costs of manufacturers of telecommunications equipment and CPE. </p>
   <h4>C. Executive Order 13132: Federalism</h4>
   <p>The final rule adheres to the fundamental Federalism principles and policy making criteria in Executive Order
     13132. The Revised 508 Standards apply to the development, procurement, maintenance, or use of ICT by Federal
@@ -3220,7 +3118,7 @@ version: original
     equipment for the four categories of information collections under the final rule as follows:</p>
   <table class="data">
     <caption>
-      Table 11 - Estimated Annual Recordkeeping and Documentation Burden
+    Table 11 - Estimated Annual Recordkeeping and Documentation Burden
     </caption>
     <thead>
       <tr>
@@ -3334,17 +3232,16 @@ version: original
     provided below relating to public availability, a copy of each referenced standard is available for inspection at
     the Access Board's office, 1331 F Street NW, Suite 1000, Washington, DC 20004.</p>
   <p><em>ATSC A/53 Part 5: 2014, Digital Television Standard, Part 5—2014 AC-3 Audio System Characteristics (2014) (see
-      414.1.1, 702.2.1).</em> The standard for digital television provides the system characteristics for advanced
+    414.1.1, 702.2.1).</em> The standard for digital television provides the system characteristics for advanced
     television systems. The document and its normative parts provide detailed specification of system parameters. Part 5
     provides the audio system characteristics and normative specifications. It includes the Visually Impaired (VI)
     associated service, which is a complete program mix containing music, effects, dialogue and a narrative description
     of the picture content. Availability: Copies of this standard may be obtained from the Advanced Television Systems
     Committee (ATSC), 1776 K Street NW, Suite 200, Washington, DC 20006–2304. Free copies of ATSC A/53 Digital
     Television Standard are available online at the organization's Web site (<a
-      href="https://atsc.org/wp-content/uploads/2015/03/A53-Part-5-2014.pdf">https://atsc.org/wp-content/uploads/2015/03/A53-Part-5-2014.pdf</a>).
-  </p>
+      href="https://atsc.org/wp-content/uploads/2015/03/A53-Part-5-2014.pdf">https://atsc.org/wp-content/uploads/2015/03/A53-Part-5-2014.pdf</a>). </p>
   <p><em>ANSI/AIIM/ISO 14289-1-2016, Document Management Applications – Electronic Document File Format Enhancement for
-      Accessibility - Part 1: Use of ISO 32000-1 (2016) (PDF/UA-1) (see 504.2.2, 702.3.1).</em> This standard (known as
+    Accessibility - Part 1: Use of ISO 32000-1 (2016) (PDF/UA-1) (see 504.2.2, 702.3.1).</em> This standard (known as
     PDF/UA-1) defines how to represent electronic documents in the PDF format in a manner that allows the file to be
     accessible. This is accomplished by identifying the set of PDF components that may be used and restrictions on the
     form of their use. Availability: Copies of this standard may be obtained from Association for Information and Image
@@ -3357,7 +3254,7 @@ version: original
       href="https://ibr.ansi.org/Standards/hfes.aspx">https://ibr.ansi.org/Standards/hfes.aspx</a>) following
     publication of the final rule.</p>
   <p><em>ANSI/HFES 200.2, Human Factors Engineering of Software User Interfaces – Part 2: Accessibility (2008) (see
-      502.4, 702.4.1).</em> This standard provides design specifications for human-system software interfaces to
+    502.4, 702.4.1).</em> This standard provides design specifications for human-system software interfaces to
     increase accessibility for persons with disabilities. It covers the design of accessible software for people with a
     wide range of physical, sensory and cognitive abilities, including those with temporary disabilities and older
     adults. Availability: Copies of this standard may be obtained from the Human Factors and Ergonomics Society (HFES),
@@ -3369,7 +3266,7 @@ version: original
       href="https://ibr.ansi.org/Standards/hfes.aspx">https://ibr.ansi.org/Standards/hfes.aspx</a>) following
     publication of the final rule.</p>
   <p><em>ANSI/IEEE C63.19-2011 American National Standard for Methods of Measurement of Compatibility between Wireless
-      Communications Devices and Hearing Aids (2011) (see 412.3.1, 702.5.1)</em>. This standard provides a uniform
+    Communications Devices and Hearing Aids (2011) (see 412.3.1, 702.5.1)</em>. This standard provides a uniform
     method of measurement for compatibility between hearing aids and wireless communications devices. Availability:
     Copies of this standard may be obtained from the Institute of Electrical and Electronics Engineers (IEEE), 10662 Los
     Vaqueros Circle, P.O. Box 3014, Los Alamitos, CA 90720–1264. This standard is also available for purchase on the
@@ -3380,19 +3277,17 @@ version: original
     with disabilities. Availability: Copies of this standard may be obtained from ICC Publications, 4051 W. Flossmoor
     Road, Country Club Hills, IL 60478-5795 (<a href="http://www.iccsafe.org">http://www.iccsafe.org</a>). A free,
     read-only version of ICC A117.1 is available online at the ICC's public access standards portal (<a
-      href="http://codes.iccsafe.org/app/book/toc/ICC%20Standards/ICC%20A117.1-2009/index.html">http://codes.iccsafe.org/app/book/toc/ICC%20Standards/ICC%20A117.1-2009/index.html</a>).
-  </p>
+      href="http://codes.iccsafe.org/app/book/toc/ICC%20Standards/ICC%20A117.1-2009/index.html">http://codes.iccsafe.org/app/book/toc/ICC%20Standards/ICC%20A117.1-2009/index.html</a>). </p>
   <p><em>ITU-T Recommendation E.161, Series E: Overall Network Operation, Telephone Service, Service Operation and Human
-      Factors—International operation – Numbering plan of the international telephone service, Arrangement of digits,
-      letters and symbols on telephones and other devices that can be used for gaining access to a telephone network
-      (2001) (see 407.3.3, 702.7.1).</em> This standard defines the assignment of the basic 26 Latin letters (A to Z) to
+    Factors—International operation – Numbering plan of the international telephone service, Arrangement of digits,
+    letters and symbols on telephones and other devices that can be used for gaining access to a telephone network
+    (2001) (see 407.3.3, 702.7.1).</em> This standard defines the assignment of the basic 26 Latin letters (A to Z) to
     the 12-key telephone keypad. Availability: This standard may be obtained from ITU-T, Place des Nations CH-1211,
     Geneva 20, Switzerland. Free copies of ITU-T Recommendation E.161 are available online at the organization's Web
-    site (<a href="http://www.itu.int/rec/T-REC-E.161-200102-I/en">http://www.itu.int/rec/T-REC-E.161-200102-I/en</a>).
-  </p>
+    site (<a href="http://www.itu.int/rec/T-REC-E.161-200102-I/en">http://www.itu.int/rec/T-REC-E.161-200102-I/en</a>). </p>
   <p><em>ITU-T Recommendation G.722.2: Series G: Transmission Systems and Media, Digital Systems and Networks, Digital
-      terminal equipments – Coding of analogue signals by methods other than PCM, Wideband coding of speech at around 16
-      kbit/s using Adaptive Multi-Rate Wideband (AMR-WB) (2003) (see 412.4, 702.7.2).</em> This standard describes the
+    terminal equipments – Coding of analogue signals by methods other than PCM, Wideband coding of speech at around 16
+    kbit/s using Adaptive Multi-Rate Wideband (AMR-WB) (2003) (see 412.4, 702.7.2).</em> This standard describes the
     high quality Adaptive Multi-Rate Wideband (AMR-WB) encoder and decoder that is primarily intended for 7 kHz
     bandwidth speech signals. AMR-WB operates at a multitude of bit rates ranging from 6.6 kbit/s to 23.85 kbit/s.
     Availability: This standard may be obtained from the International Telecommunication Union, Telecommunications
@@ -3407,7 +3302,7 @@ version: original
     Engineering Task Force's Web site (<a
       href="http://www.rfc-base.org/txt/rfc-6716.txt">http://www.rfc-base.org/txt/rfc-6716.txt</a>).</p>
   <p><em>TIA-1083-B: Telecommunications—Communications Products—Handset Magnetic Measurement Procedures and Performance
-      Requirements (2015) (TIA-1083-B) (see 412.3.2, 702.9.1).</em> This standard defines measurement procedures and
+    Requirements (2015) (TIA-1083-B) (see 412.3.2, 702.9.1).</em> This standard defines measurement procedures and
     performance requirements for the handset generated audio band magnetic noise of wireline telephones. This standard
     also addresses magnetic interference issues not covered by 47 CFR part 68. This standard can be used to evaluate
     devices with analog interfaces and digital interfaces that provide narrowband and wideband transmission.
@@ -3418,9 +3313,9 @@ version: original
     representatives to explore potential options for making TIA-1083-B readily available to the public. TIA took the
     position that this standard is available for sale and is, therefore, reasonably available.</p>
   <p><em>WCAG 2.0, Web Content Accessibility Guidelines, W3C Recommendation (2008) (see E205.4, E205.4 Exception,
-      E205.4.1, E207.2, E207.2 Exception 2, E207.2 Exception 3, E207.2.1, E207.3, C203.1, C203.1 Exception, C203.1.1,
-      C205.2, C205.2 Exception 2, C205.2 Exception 3, C205.2.1, C205.3, 408.3 Exception, 501.1 Exception, 504.2, 504.3,
-      504.4, 602.3, and 702.10.1)</em>. WCAG 2.0, published by the W3C Web Accessibility Initiative (W3C), specifies
+    E205.4.1, E207.2, E207.2 Exception 2, E207.2 Exception 3, E207.2.1, E207.3, C203.1, C203.1 Exception, C203.1.1,
+    C205.2, C205.2 Exception 2, C205.2 Exception 3, C205.2.1, C205.3, 408.3 Exception, 501.1 Exception, 504.2, 504.3,
+    504.4, 602.3, and 702.10.1)</em>. WCAG 2.0, published by the W3C Web Accessibility Initiative (W3C), specifies
     success criteria and requirements to make Web content more accessible to all users, including persons with
     disabilities. The W3C Web site also provides online technical assistance materials linked to each success criteria
     and technical requirement. Availability: Copies of this standard may be obtained from the W3C Web Accessibility
@@ -3446,8 +3341,7 @@ version: original
       contained minor editorial changes only relative to the 2014 version. See ETSI/CEN/CENELEC, EN 301 549 V1.1.2
       (2015-04), Accessibility Requirements Suitable for Public Procurement of ICT Products and Services in Europe (Apr.
       2015), available at <a
-        href="http://www.etsi.org/deliver/etsi_en/301500_301599/301549/01.01.02_60/en_301549v010102p.pdf">http://www.etsi.org/deliver/etsi_en/301500_301599/301549/01.01.02_60/en_301549v010102p.pdf</a>.
-    </li>
+        href="http://www.etsi.org/deliver/etsi_en/301500_301599/301549/01.01.02_60/en_301549v010102p.pdf">http://www.etsi.org/deliver/etsi_en/301500_301599/301549/01.01.02_60/en_301549v010102p.pdf</a>. </li>
     <li>The existing 508 Standards require that technology provide at least one mode of operation and information
       retrieval not requiring visual acuity greater than 20/70 in both audio and enlarged print output, working together
       or independently. 36 CFR § 1194.31(b). The limited vision FPC in the existing 255 Guidelines is similar; it
@@ -3467,8 +3361,7 @@ version: original
       Enabled).</li>
     <li>See also Office of Management and Budget, Circular A-4 (2003); Office of Management and Budget, Regulatory
       Impact Analysis: A Primer 3 (2011), available at <a
-        href="http://www.whitehouse.gov/sites/default/files/omb/inforeg/regpol/circular-a-4_regulatory-impact-analysis-a-primer.pdf">http://www.whitehouse.gov/sites/default/files/omb/inforeg/regpol/circular-a-4_regulatory-impact-analysis-a-primer.pdf</a>.
-    </li>
+        href="http://www.whitehouse.gov/sites/default/files/omb/inforeg/regpol/circular-a-4_regulatory-impact-analysis-a-primer.pdf">http://www.whitehouse.gov/sites/default/files/omb/inforeg/regpol/circular-a-4_regulatory-impact-analysis-a-primer.pdf</a>. </li>
     <li>Examples of CPE include wireline and wireless telephones or computers when employed on the premises of a person
       to originate, route, or terminate telecommunications (e.g., Internet telephony, interconnected VoIP). Only a
       computer with a modem or internet telephony software can function as telecommunications equipment and only the
@@ -3482,8 +3375,7 @@ version: original
         href="http://www.census.gov/eos/www/naics/">http://www.census.gov/eos/www/naics/</a> SBA provides, on its Web
       site, small business size standards for each NAICS code. See U.S. Small Business Administration, Table of Small
       Business Size Standards, <a
-        href="https://www.sba.gov/contracting/getting-started-contractor/make-sure-you-meet-sba-size-standards/table-small-business-size-standards">https://www.sba.gov/contracting/getting-started-contractor/make-sure-you-meet-sba-size-standards/table-small-business-size-standards</a>
-      (updated Feb. 26, 2016).</li>
+        href="https://www.sba.gov/contracting/getting-started-contractor/make-sure-you-meet-sba-size-standards/table-small-business-size-standards">https://www.sba.gov/contracting/getting-started-contractor/make-sure-you-meet-sba-size-standards/table-small-business-size-standards</a> (updated Feb. 26, 2016).</li>
     <li>Dept. of Transportation, Nondiscrimination on the Basis of Disability in Air Travel: Accessibility of Web Sites
       and Automated Kiosks at U.S. Airports, 78 FR 67882 (Nov. 12, 2013); Econometrica, Inc., Final Regulatory Analysis
       on the Final Rule on Accessible Kiosks and Web Sites (Oct. 23, 2013), available at <a
@@ -3494,8 +3386,7 @@ version: original
       with Federal law, certain SUSB data elements are "masked" (e.g., receipts for a particular establishment size
       range) when publication would disclose the identity of individual business establishments. See U.S. Census Bureau,
       Statistics of U.S Businesses (SUSB) – Methodology, <a
-        href="http://www.census.gov/programs-surveys/susb/technical-documentation/methodology.html">http://www.census.gov/programs-surveys/susb/technical-documentation/methodology.html</a>
-      (last revised June 8, 2016); see also 13 U.S.C. 9. As a result, when calculating average per-firm annual receipts
+        href="http://www.census.gov/programs-surveys/susb/technical-documentation/methodology.html">http://www.census.gov/programs-surveys/susb/technical-documentation/methodology.html</a> (last revised June 8, 2016); see also 13 U.S.C. 9. As a result, when calculating average per-firm annual receipts
       presented for each NAICS codes in Table 9 and Table 10, it was occasionally necessary to estimate missing data
       elements using other available, pertinent data for that NAICS code.</li>
   </ol>
@@ -3511,17 +3402,17 @@ version: original
     4. Remove the designations of subparts A through D<br />
     5. Add appendix D to part 1194 to read as follows:</p>
   <p><strong>Appendix D to Part 1194 - Electronic and Information Technology Accessibility Standards as Originally
-      Published on December 21, 2000</strong><br />
+    Published on December 21, 2000</strong><br />
     Sections D1194.6 through D1194.20 [Reserved]<br />
     Sections D1194.27 through D1194.30 [Reserved]<br />
     Sections D1194.32 through D1194.40 [Reserved]<br />
     Sections D1194.42 through D1194.50 [Reserved]</p>
   <p><strong>§§ 1194.1 through 1194.5 [Transferred to Appendix D to Part 1194 as Sections D1194.1 through
-      D1194.5]</strong> <br />
+    D1194.5]</strong> <br />
     6. Redesignate §§ 1194.1 through 1194.5 as sections D1194.1 through D1194.5, respectively, and transfer to appendix
     D to part 1194.</p>
   <p><strong>§§ 1194.21 through 1194.26 [Transferred to Appendix D to Part 1194 as Sections D1194.21 through
-      D1194.26]</strong></p>
+    D1194.26]</strong></p>
   <p>7. Redesignate §§ 1194.21 through 1194.26 as sections D1194.21 through D1194.26, respectively, and transfer to
     appendix D to part 1194.</p>
   <p><strong>§ 1194.31 [Transferred to Appendix D to Part 1194 as Section D1194.31]</strong> <br />


### PR DESCRIPTION
Many internal links were no longer working, and with left sidebar navigation, the navigation links at top of major sections were redundant.