### PR TITLE
External Links Testing

### DIFF
--- a/_assets/css/index.scss
+++ b/_assets/css/index.scss
@@ -38,7 +38,7 @@ h5, h6 { // default was xs and 2xs
 
 // Add your SASS/CSS here
 
-a.external::after { content: " [external link] "; }
+a.external::after { content: " (external link)"; }
 
 // stylish faux 'page-breaks'
 hr {

--- a/_assets/css/index.scss
+++ b/_assets/css/index.scss
@@ -38,6 +38,8 @@ h5, h6 { // default was xs and 2xs
 
 // Add your SASS/CSS here
 
+a.external::after { content: " [external link] "; }
+
 // stylish faux 'page-breaks'
 hr {
   border: solid;

--- a/_assets/js/external-links.js
+++ b/_assets/js/external-links.js
@@ -33,8 +33,7 @@
       const nonGovDomain = isNonGovDomain(domain);
 
       if (nonGovDomain) {
-        a.className = a.className + " " + "usa-link--external";
-        a.setAttribute("title", "external link")
+        a.className = "external";
       }
     }
   }

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -3,7 +3,7 @@
     <div class="grid-container maxw-desktop">
       <div class="grid-row padding-3">
         <div class="tablet:grid-col text-center">
-           <span class="logo-links">
+          <p>
             <a href="{{ site.baseurl }}/guidance.html">Guidance Documents</a> &nbsp;
             <a href="{{ site.baseurl }}/about/policy/accessibility.html">Accessibility</a> &nbsp;
             <a href="{{ site.baseurl }}/about/par.html">Budget and Performance</a> &nbsp;
@@ -11,9 +11,15 @@
             <a href="{{ site.baseurl }}/about/policy/foia.html" title="Freedom of Information Act">FOIA</a> &nbsp;
             <a href="{{ site.baseurl }}/about/policy/privacy.html" title="Privacy Policy">Privacy</a> &nbsp;
             <a href="https://osc.gov/agency" title="U.S. Office of Special Counsel">OSC.gov</a> &nbsp;
-            <a href="https://usa.gov" title="Have a question about government services?">USA.gov</a> <br />
+            <a href="https://usa.gov" title="Have a question about government services?">USA.gov</a>
+          </p>
+          <p>
+            The content of external links to non-Federal Agency websites is not endorsed by the Federal Government and is not subject to Federal information quality,
+            privacy, security, and related guidelines.
+          </p>
+          <p>
             <a class="footer-logo media_link" href="{{ site.baseurl }}/">{% asset usab-logo.svg alt="usab logo" width="50" %}</a>
-          </span>
+          <p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
From [Required Web Content and Links](https://digital.gov/resources/required-web-content-and-links/?dg#external-links):

Agencies must clearly identify external links from their websites, and to the extent practicable update or remove the links when the external information is no longer sufficiently accurate, relevant, timely, necessary or complete.
1. Agency websites must clearly state that **the content of external links to non-Federal Agency websites is not endorsed by the Federal Government and is not subject to Federal information quality, privacy, security, and related guidelines**.
2. Agencies should choose the best approach to identify external links to users in a way that minimizes the impact on the usability of their websites and digital services.