### PR TITLE
Fixes for ada_es

### DIFF
--- a/_ada-aba_es/ada-enhanced_es.html
+++ b/_ada-aba_es/ada-enhanced_es.html
@@ -6,7 +6,7 @@ image-directory: /images/ada-aba/standards_es/
 file: /files/ada/ADA-Standards.pdf
 file-description: Versión en PDF de un solo archivo de las Normas de la ADA
 ---
-{% assign ada-chapters = site.ada | where: "title","Sobre la ADA" %}
+{% assign ada-chapters = site.ada-aba_es | where: "title","Sobre la ADA" %}
 {% for chapter in ada-chapters %}
 <div>{{chapter.content | markdownify}}</div>
 {% endfor %}

--- a/_ada-aba_es/ada-enhanced_es.html
+++ b/_ada-aba_es/ada-enhanced_es.html
@@ -11,13 +11,13 @@ file-description: Versión en PDF de un solo archivo de las Normas de la ADA
 <div>{{chapter.content | markdownify}}</div>
 {% endfor %}
 <hr/>
-{% assign ada-chapters = site.ada-es | where: "title","Introducción a los estándares de la ADA" %}
+{% assign ada-chapters = site.ada-aba_es | where: "title","Introducción a los estándares de la ADA" %}
 {% for chapter in ada-chapters %}
 <div>{{chapter.content | markdownify}}</div>
 {% endfor %}
 <hr/>
 {%- comment -%}
-{% assign ada-chapters = site.ada | where: "title","Estándares de la ADA de 2010 del DOJ" %}
+{% assign ada-chapters = site.ada-aba_es | where: "title","Estándares de la ADA de 2010 del DOJ" %}
 {% for chapter in ada-chapters %}
 <h1>{{chapter.title}}</h1>
 <div class="usa-prose">{{chapter.content}}</div>

--- a/_ada-aba_es/ada-enhanced_es.html
+++ b/_ada-aba_es/ada-enhanced_es.html
@@ -11,7 +11,7 @@ file-description: Versión en PDF de un solo archivo de las Normas de la ADA
 <div>{{chapter.content | markdownify}}</div>
 {% endfor %}
 <hr/>
-{% assign ada-chapters = site.ada | where: "title","Introducción a los estándares de la ADA" %}
+{% assign ada-chapters = site.ada-es | where: "title","Introducción a los estándares de la ADA" %}
 {% for chapter in ada-chapters %}
 <div>{{chapter.content | markdownify}}</div>
 {% endfor %}

--- a/_assets/css/styles.scss
+++ b/_assets/css/styles.scss
@@ -65,11 +65,11 @@ a.style-inherit {
   text-decoration: inherit; // no underline
 }
 
-
 button {
   a:link { text-decoration:none; }
   a:hover { text-decoration:underline; }
-  a:active { color:aqua !important; text-decoration:underline; }
+  a:focus { text-decoration:underline; }
+  a:active { text-decoration:underline; color:gray !important; }
   a:visited { text-decoration:none; }
 }
 

--- a/_includes/toc/ada_es.html
+++ b/_includes/toc/ada_es.html
@@ -19,8 +19,8 @@
 					  > Sobre la ADA </button>
               <ul id="toc-about"
 				  class="usa-accordion__content usa-sidenav__sublist" aria-label="Navegación de secciones de página">
-                <li class="usa-sidenav__item"><a href="#about-the-ada-accessibility-standards">Sobre los Estándares de Accesibilidad de la ADA</a></li>
-                <li class="usa-sidenav__item"><a href="#background">Antecedentes</a></li>
+                <li class="usa-sidenav__item"><a href="#sobre-los-estándares-de-accesibilidad-de-la-ada">Sobre los Estándares de Accesibilidad de la ADA</a></li>
+                <li class="usa-sidenav__item"><a href="#antecedentes">Antecedentes</a></li>
               </ul>
             </li>
             <li class="usa-sidenav__item">
@@ -29,8 +29,8 @@
 					  aria-controls="toc-intro"
 					  > Introducción a la ADA </button>
               <ul id="toc-intro" class="usa-accordion__content usa-sidenav__sublist" aria-label="Navegación de secciones de página">
-                <li class="usa-sidenav__item"><a href="#department-of-justice-ada-standards-2010">Estándares de la ADA del Departamento de Justicia (2010)</a></li>
-                <li class="usa-sidenav__item"><a href="#department-of-transportation-ada-standards-for-transportation-facilities-2006">Estándares de la ADA para Instalaciones de Transporte del Departamento de Transporte (2006)</a></li>
+                <li class="usa-sidenav__item"><a href="#estándares-de-la-ada-del-departamento-de-justicia-2010">Estándares de la ADA del Departamento de Justicia (2010)</a></li>
+                <li class="usa-sidenav__item"><a href="#estándares-de-la-ada-para-instalaciones-de-transporte-del-departamento-de-transporte-2006">Estándares de la ADA para Instalaciones de Transporte del Departamento de Transporte (2006)</a></li>
               </ul>
             </li>
             <li class="usa-sidenav__item">

--- a/_includes/toc/ada_es.html
+++ b/_includes/toc/ada_es.html
@@ -31,8 +31,6 @@
               <ul id="toc-intro" class="usa-accordion__content usa-sidenav__sublist" aria-label="Navegación de secciones de página">
                 <li class="usa-sidenav__item"><a href="#estándares-de-la-ada-del-departamento-de-justicia-2010">Estándares de la ADA del Departamento de Justicia (2010)</a></li>
                 <li class="usa-sidenav__item"><a href="#estándares-de-la-ada-para-instalaciones-de-transporte-del-departamento-de-transporte-2006">Estándares de la ADA para Instalaciones de Transporte del Departamento de Transporte (2006)</a></li>
-                <li class="usa-sidenav__item"><a href="#estándares-de-la-ada-del-departamento-de-justicia-(2010)">Estándares de la ADA del Departamento de Justicia (2010)</a></li>
-                <li class="usa-sidenav__item"><a href="#estándares-de-la-ada-para-instalaciones-de-transporte-del-departamento-de-transporte-(2006)">Estándares de la ADA para Instalaciones de Transporte del Departamento de Transporte (2006)</a></li>
               </ul>
             </li>
             <li class="usa-sidenav__item">


### PR DESCRIPTION
1. files pulled in
2. left nav to correct section

[Preview](https://federalist-e3fba26d-2806-4f02-bf0e-89c97cfba93c.sites.pages.cloud.gov/preview/atbcb/usab-uswds/ada-es-ke/ada-es/#est%C3%A1ndares-de-la-ada-para-instalaciones-de-transporte-del-departamento-de-transporte-2006)

Should go in an issue but please check the Spanish in the TOC matches the content:
- TOC 101 Proposito goes to 101 Objetivo in the content