### PR TITLE
Update Netlify CMS linkage post Federalist to Cloud.gov Pages

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -2,9 +2,9 @@
 backend:
   name: github
   repo: atbcb/usab-uswds
-  base_url: https://federalistapp.18f.gov
+  base_url: https://pages.cloud.gov
   auth_endpoint: external/auth/github
-  preview_context: federalist/build
+  preview_context: pages/build
   branch: beta
   use_graphql: false
 


### PR DESCRIPTION
Update two lines in `_config.yml`

backend:
- base_url: federalistapp.18f.gov --> base_url: pages.cloud.gov
- preview_context: federalist/build --> pages/build


